### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     name: Test on Python ${{ matrix.python-version }}
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/WxboySuper/Esports-Pickem-Discord-Bot/security/code-scanning/2](https://github.com/WxboySuper/Esports-Pickem-Discord-Bot/security/code-scanning/2)

To fix this issue, add a `permissions` block to the job (or at the workflow root) limiting the permissions of the GITHUB_TOKEN. Since this CI workflow only checks out code and uploads coverage, the minimal required privileges are generally read access to repository contents. Therefore, add `permissions: contents: read` right under the job definition at line 11, or at the workflow root (line 2 or 3). This change limits the GITHUB_TOKEN so it can only read repository contents, adhering to least privilege principles. No other code edits in this file are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
