### PR TITLE
feat: Add test plan and initial test cases for bot functionality

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,2 @@
+pytest==8.4.2
+pytest-asyncio==1.2.0

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -1,0 +1,78 @@
+# Test Plan: Esports Pick'em Discord Bot
+
+## Scope
+
+Covers basic bot skeleton, command registration, and minimal functionality for Issue #2.
+
+---
+
+## 1. Automated Tests
+
+### Run All Unit Tests
+
+- Install dependencies (including `pytest`, `pytest-asyncio`):
+
+```bash
+  pip install -r requirements.txt
+  pip install pytest pytest-asyncio
+```
+
+- Run tests:
+
+```bash
+  python -m pytest -v tests/
+```
+
+#### Tests covered
+
+- **Package imports**: Verifies `src.commands` is importable.
+- **Command modules**: Each module in `src.commands` exposes a `setup()` function.
+- **Bot instantiation**: Bot can be created (does not crash).
+- **Ping command setup**: `ping` command/cog setup can be loaded (sync or async).
+
+---
+
+## 2. Manual Verification
+
+### Service Startup
+
+- Start the Discord bot service (systemd, docker, or CLI).
+- Check logs for:
+  - Successful login (e.g., "Logged in as ...")
+  - Loaded command modules (e.g., "Loaded command module: ...")
+  - Global command sync (e.g., "Performed GLOBAL command sync.")
+
+### Discord Command Check
+
+- In a Discord server where the bot is present:
+  - Use `/ping` or `!ping` and verify the bot responds appropriately.
+  - Use `/help` or `!help` and verify the help/info command responds.
+
+---
+
+## 3. Error Handling
+
+- Confirm that missing/invalid `DISCORD_TOKEN` in env causes the bot to log a clear error and exit.
+- If a command module fails to load or has no `setup`, this is reported in logs and does not crash the bot.
+
+---
+
+## 4. CI/CD
+
+- Ensure the GitHub Actions workflow (if present) runs `pytest` on push/PR and reports status.
+
+---
+
+## 5. Acceptance Criteria
+
+- All automated tests pass.
+- Bot starts and commands register (see logs).
+- Manual Discord command check succeeds.
+- No unhandled exceptions or warnings in logs.
+- Documentation (README and this file) describes testing steps.
+
+---
+
+## Notes
+
+- For further development: add integration tests for user flows, scoring, DB functions, and adapters.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]
+# (optional) add other pytest options if desired

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
 discord.py==2.6.3
 python-dotenv==1.1.1  # optional for local dev if you want to load .env
-pytest==8.4.2
-pytest-asyncio==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 discord.py==2.6.3
 python-dotenv==1.1.1  # optional for local dev if you want to load .env
+pytest==8.4.2
+pytest-asyncio==1.2.0

--- a/tests/test_bot_skeleton.py
+++ b/tests/test_bot_skeleton.py
@@ -1,14 +1,7 @@
 import importlib
 import pkgutil
-import os
-import sys
 import pytest
 import inspect
-
-# Ensure src/ is importable
-sys.path.insert(0, os.path.abspath(
-    os.path.join(os.path.dirname(__file__), "..", "src")
-))
 
 
 def test_commands_package_importable():

--- a/tests/test_bot_skeleton.py
+++ b/tests/test_bot_skeleton.py
@@ -1,0 +1,65 @@
+import importlib
+import pkgutil
+import os
+import sys
+import pytest
+import inspect
+
+# Ensure src/ is importable
+sys.path.insert(0, os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "src")
+))
+
+
+def test_commands_package_importable():
+    """The src.commands package should be importable and have a __path__."""
+    import src.commands as commands_pkg
+    assert hasattr(commands_pkg, "__path__")
+
+
+def test_each_command_module_has_setup():
+    """Each command module in src.commands should define a setup() function."""
+    import src.commands as commands_pkg
+    failures = []
+    for module_info in pkgutil.iter_modules(commands_pkg.__path__):
+        name = module_info.name
+        if name.startswith("_"):
+            continue
+        full_name = f"{commands_pkg.__name__}.{name}"
+        try:
+            mod = importlib.import_module(full_name)
+        except Exception as e:
+            failures.append(f"import failed: {full_name}: {e}")
+            continue
+        if not hasattr(mod, "setup"):
+            failures.append(f"no setup(): {full_name}")
+    assert not failures, "Module issues:\n" + "\n".join(failures)
+
+
+def test_bot_can_instantiate(monkeypatch):
+    """Bot class can instantiate with minimal env (no crash)."""
+    # Patch env so DISCORD_TOKEN is present
+    monkeypatch.setenv("DISCORD_TOKEN", "dummy")
+    from src.app import EsportsBot
+    bot = EsportsBot()
+    assert bot is not None
+
+
+@pytest.mark.asyncio
+async def test_ping_command_loads(monkeypatch):
+    """
+    Checks that the ping command cog can be loaded without error.
+    Properly awaits async setup functions to avoid warnings.
+    """
+    monkeypatch.setenv("DISCORD_TOKEN", "dummy")
+    from src.app import EsportsBot
+    bot = EsportsBot()
+    import src.commands.ping as ping_mod
+
+    setup_fn = getattr(ping_mod, "setup", None)
+    assert setup_fn is not None
+
+    if inspect.iscoroutinefunction(setup_fn):
+        await setup_fn(bot)
+    else:
+        setup_fn(bot)


### PR DESCRIPTION
# PR title format

feat: Add test plan and initial test cases for bot functionality

## Description

Adds a comprehensive `TEST_PLAN.md` for the bot skeleton and command registration, along with initial unit tests to verify command discovery, bot instantiation, and command module setup. Ensures the bot skeleton is robust and testable for future expansion.

## Related issues

Closes #2

## Checklist

- [x] I have read the CONTRIBUTING.md (or ITERATIONS.md if CONTRIBUTING.md is not present)
- [x] Code changes include tests where applicable
- [x] Relevant documentation has been updated (README, ITERATIONS.md)
- [x] CI passes (or changes to CI are documented)

## How to test / QA steps

1. Run `pip install pytest pytest-asyncio`
2. Run `python -m pytest -v tests/`
3. Verify all tests pass and no warnings/errors are present
4. Optionally, review `TEST_PLAN.md` for manual and automated test guidance

## Acceptance criteria

- All automated tests pass
- Manual test steps (service startup, Discord `/ping` command) succeed
- `TEST_PLAN.md` is clear and matches repository functionality
- No regressions or new warnings/errors in CI

## Size

S

## Notes for reviewers

No database or environment changes required. No migrations.  
If any command modules are added in the future, ensure they expose a `setup()` function for test coverage.