### PR TITLE
Fix: Correct CI workflow to fail on errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,49 +32,22 @@ jobs:
           pip install -r requirements.txt
         fi
         # Install dev requirements if they exist
-        if [ -f requirements-dev.txt ]; then
-          pip install -r requirements-dev.txt
+        if [ -f dev-requirements.txt ]; then
+          pip install -r dev-requirements.txt
         fi
-        # Install common development tools for linting and testing
-        pip install flake8 black pytest pytest-cov || true
 
     - name: Lint with flake8
       run: |
-        # Check if flake8 is available and run it
-        if command -v flake8 &> /dev/null; then
-          echo "Running flake8 linting..."
-          # Stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics || true
-          # Exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics || true
-        else
-          echo "flake8 not available, skipping linting"
-        fi
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        flake8 . --count --max-complexity=10 --max-line-length=127 --statistics
 
     - name: Format check with black
       run: |
-        # Check if black is available and run it
-        if command -v black &> /dev/null; then
-          echo "Checking code formatting with black..."
-          black --check . || echo "Code formatting check completed (non-blocking)"
-        else
-          echo "black not available, skipping format check"
-        fi
+        black --check .
 
     - name: Test with pytest
       run: |
-        # Check if pytest is available and run tests
-        if command -v pytest &> /dev/null; then
-          echo "Running tests with pytest..."
-          # Run tests if test directory exists
-          if [ -d "tests" ] || [ -d "test" ]; then
-            pytest --cov=src --cov-report=xml || echo "Tests completed with some failures (non-blocking for now)"
-          else
-            echo "No test directory found, skipping tests"
-          fi
-        else
-          echo "pytest not available, skipping tests"
-        fi
+        pytest --cov=src --cov-report=xml
 
     - name: Upload coverage to Codecov
       if: matrix.python-version == '3.10'

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,20 +1,17 @@
 import os
 import sys
 from logging.config import fileConfig
+import importlib
 
 from sqlalchemy import engine_from_config, pool
 from sqlmodel import SQLModel
 
 from alembic import context
 
-# Add project root to the Python path
-# This is necessary for alembic to find the models in the src directory
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+# Add project root to the Python path so Alembic can find models in src
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, project_root)
 
-
-# importlib is used to import the models module so model classes are registered
-# without using a wildcard import or leaving an unused import name.
-import importlib
 importlib.import_module("src.models")
 
 config = context.config
@@ -27,7 +24,7 @@ def run_migrations_offline():
         url=config.get_main_option("sqlalchemy.url"),
         target_metadata=target_metadata,
         literal_binds=True,
-        compare_type=True
+        compare_type=True,
     )
     with context.begin_transaction():
         context.run_migrations()
@@ -37,13 +34,13 @@ def run_migrations_online():
     connectable = engine_from_config(
         config.get_section(config.config_ini_section),
         prefix="sqlalchemy.",
-        poolclass=pool.NullPool
+        poolclass=pool.NullPool,
     )
     with connectable.connect() as connection:
         context.configure(
             connection=connection,
             target_metadata=target_metadata,
-            compare_type=True
+            compare_type=True,
         )
         with context.begin_transaction():
             context.run_migrations()

--- a/alembic/versions/001_create_base_tables.py
+++ b/alembic/versions/001_create_base_tables.py
@@ -5,6 +5,7 @@ Revises:
 Create Date: 2025-09-23
 
 """
+
 from alembic import op
 from sqlmodel import SQLModel
 
@@ -12,25 +13,30 @@ from sqlmodel import SQLModel
 # on its metadata object. The path to the models is configured in
 # alembic/env.py.
 try:
-    from src import models
+    from src import models  # noqa: F401
 except ImportError as e:
     import sys
     import os
+
     # Try to add the parent directory containing 'src' to sys.path
-    src_path = os.path.join(os.path.dirname(__file__), '..', '..', 'src')
+    src_path = os.path.join(os.path.dirname(__file__), "..", "..", "src")
     src_path = os.path.abspath(src_path)
     if src_path not in sys.path:
         sys.path.insert(0, src_path)
     try:
-        from src import models
+        from src import models  # noqa: F401
     except ImportError:
         raise ImportError(
-            "Could not import 'src.models'. Make sure the 'src' directory is in your PYTHONPATH "
-            "and that you are running Alembic from the project root. Original error: {}".format(e)
+            (
+                "Could not import 'src.models'. "
+                "Make sure the 'src' directory is in your PYTHONPATH and "
+                "that you are running Alembic from the project root. "
+                f"Original error: {e}"
+            )
         )
 
 # revision identifiers, used by Alembic.
-revision = '001'
+revision = "001"
 down_revision = None
 branch_labels = None
 depends_on = None

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,3 +2,4 @@ pytest==8.4.2
 pytest-asyncio==1.2.0
 flake8==7.3.0
 black==25.9.0
+pytest-cov==7.0.0-py3

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,4 @@
 pytest==8.4.2
 pytest-asyncio==1.2.0
+flake8
+black

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
 pytest==8.4.2
 pytest-asyncio==1.2.0
-lake8==7.3.0
+flake8==7.3.0
 black==25.9.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
 pytest==8.4.2
 pytest-asyncio==1.2.0
-flake8
-black
+lake8==7.3.0
+black==25.9.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,4 +2,4 @@ pytest==8.4.2
 pytest-asyncio==1.2.0
 flake8==7.3.0
 black==25.9.0
-pytest-cov==7.0.0-py3
+pytest-cov==7.0.0

--- a/src/commands/contest.py
+++ b/src/commands/contest.py
@@ -2,7 +2,6 @@
 import logging
 import discord
 from discord import app_commands
-from discord.ext import commands
 
 from src.app import ADMIN_IDS
 from src.crud import create_contest
@@ -33,8 +32,14 @@ class ContestModal(discord.ui.Modal, title="Create New Contest"):
         from datetime import datetime
 
         try:
-            start_date_val = datetime.strptime(self.start_date.value, "%Y-%m-%d")
-            end_date_val = datetime.strptime(self.end_date.value, "%Y-%m-%d")
+            start_date_val = datetime.strptime(
+                self.start_date.value,
+                "%Y-%m-%d",
+            )
+            end_date_val = datetime.strptime(
+                self.end_date.value,
+                "%Y-%m-%d",
+            )
 
             contest = create_contest(
                 session,
@@ -65,7 +70,8 @@ class Contest(app_commands.Group, name="contest", description="Manage contests")
     async def create(self, interaction: discord.Interaction):
         if interaction.user.id not in ADMIN_IDS:
             await interaction.response.send_message(
-                "You do not have permission to use this command.", ephemeral=True
+                "You do not have permission to use this command.",
+                ephemeral=True,
             )
             return
         await interaction.response.send_modal(ContestModal())

--- a/src/commands/info.py
+++ b/src/commands/info.py
@@ -8,24 +8,20 @@ logger = logging.getLogger("esports-bot.commands.info")
 
 
 async def setup(bot):
-    @bot.tree.command(name="info",
-                      description="Bot and repository information"
-                      )
+    @bot.tree.command(name="info", description="Bot and repository information")
     async def info(interaction: discord.Interaction):
         logger.debug("Info command invoked by user %s", interaction.user.id)
         embed = discord.Embed(
             title="Esports Pick'em Bot",
             description="A list of commands plus extra tips.",
-            color=0x2d9cdb,
+            color=0x2D9CDB,
         )
-        embed.add_field(name="Commands",
-                        value='\n'.join([
-                            f"/{c.name} - {c.description}"
-                            for c in bot.tree.get_commands()
-                        ]),
-                        inline=False
-                        )
-        embed.set_footer(
-            text="Configured to use slash commands (app_commands)."
-            )
+        embed.add_field(
+            name="Commands",
+            value="\n".join(
+                [f"/{c.name} - {c.description}" for c in bot.tree.get_commands()]
+            ),
+            inline=False,
+        )
+        embed.set_footer(text="Configured to use slash commands (app_commands).")
         await interaction.response.send_message(embed=embed, ephemeral=True)

--- a/src/commands/matches.py
+++ b/src/commands/matches.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone, timedelta
 
 import discord
 from discord import app_commands
-from sqlmodel import Session, select
+from sqlmodel import Session
 
 from src.db import get_session
 from src.models import Contest, Match
@@ -16,28 +16,36 @@ from src.app import ADMIN_IDS
 
 logger = logging.getLogger("esports-bot.commands.matches")
 
-matches_group = app_commands.Group(name="matches", description="Commands for viewing and managing matches.")
+matches_group = app_commands.Group(
+    name="matches", description="Commands for viewing and managing matches."
+)
 
 # --- Helper Functions and Classes ---
 
-async def create_matches_embed(title: str, matches: list[Match], interaction: discord.Interaction) -> discord.Embed:
+
+async def create_matches_embed(
+    title: str, matches: list[Match], interaction: discord.Interaction
+) -> discord.Embed:
     """Creates a standard embed for displaying a list of matches."""
     embed = discord.Embed(
         title=title,
         color=discord.Color.purple(),
-        timestamp=datetime.now(timezone.utc)
+        timestamp=datetime.now(timezone.utc),
     )
-    embed.set_author(name=interaction.user.display_name, icon_url=interaction.user.avatar.url if interaction.user.avatar else None)
+    embed.set_author(
+        name=interaction.user.display_name,
+        icon_url=(interaction.user.avatar.url if interaction.user.avatar else None),
+    )
 
     if not matches:
         embed.description = "No matches found."
     else:
         for match in matches:
-            time_str = match.scheduled_time.strftime('%H:%M UTC')
+            time_str = match.scheduled_time.strftime("%H:%M UTC")
             embed.add_field(
                 name=f"{match.team1} vs {match.team2}",
                 value=f"Time: {time_str}\nContest: {match.contest.name}",
-                inline=False
+                inline=False,
             )
     return embed
 
@@ -45,7 +53,11 @@ async def create_matches_embed(title: str, matches: list[Match], interaction: di
 class DayNavigationView(discord.ui.View):
     """A view with buttons to navigate between days."""
 
-    def __init__(self, current_date: datetime.date, interaction: discord.Interaction):
+    def __init__(
+        self,
+        current_date: datetime.date,
+        interaction: discord.Interaction,
+    ):
         super().__init__(timeout=180)
         self.current_date = current_date
         self.interaction = interaction
@@ -59,13 +71,23 @@ class DayNavigationView(discord.ui.View):
         embed = await create_matches_embed(title, matches, self.interaction)
         await interaction.edit_original_response(embed=embed, view=self)
 
-    @discord.ui.button(label="< Previous Day", style=discord.ButtonStyle.secondary)
-    async def previous_day(self, interaction: discord.Interaction, button: discord.ui.Button):
+    @discord.ui.button(
+        label="< Previous Day",
+        style=discord.ButtonStyle.secondary,
+    )
+    async def previous_day(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ):
         self.current_date -= timedelta(days=1)
         await self.update_embed(interaction)
 
-    @discord.ui.button(label="Next Day >", style=discord.ButtonStyle.secondary)
-    async def next_day(self, interaction: discord.Interaction, button: discord.ui.Button):
+    @discord.ui.button(
+        label="Next Day >",
+        style=discord.ButtonStyle.secondary,
+    )
+    async def next_day(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ):
         self.current_date += timedelta(days=1)
         await self.update_embed(interaction)
 
@@ -75,8 +97,7 @@ class TournamentSelect(discord.ui.Select):
 
     def __init__(self, contests: list[Contest]):
         options = [
-            discord.SelectOption(label=c.name, value=str(c.id))
-            for c in contests
+            discord.SelectOption(label=c.name, value=str(c.id)) for c in contests
         ]
         super().__init__(placeholder="Choose a tournament...", options=options)
 
@@ -93,7 +114,11 @@ class TournamentSelect(discord.ui.Select):
 
 # --- Commands ---
 
-@matches_group.command(name="view-by-day", description="View matches scheduled for a specific day.")
+
+@matches_group.command(
+    name="view-by-day",
+    description="View matches scheduled for a specific day.",
+)
 async def view_by_day(interaction: discord.Interaction):
     """Shows matches for the current day with navigation."""
     logger.info(f"'{interaction.user.name}' requested matches by day.")
@@ -103,42 +128,67 @@ async def view_by_day(interaction: discord.Interaction):
     title = f"Matches for {current_date.strftime('%Y-%m-%d')}"
     embed = await create_matches_embed(title, matches, interaction)
     view = DayNavigationView(current_date, interaction)
-    await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
+    await interaction.response.send_message(
+        embed=embed,
+        view=view,
+        ephemeral=True,
+    )
 
 
-@matches_group.command(name="view-by-tournament", description="View all matches for a specific tournament.")
+@matches_group.command(
+    name="view-by-tournament",
+    description="View all matches for a specific tournament.",
+)
 async def view_by_tournament(interaction: discord.Interaction):
     """Shows a dropdown to select a tournament and view its matches."""
     logger.info(f"'{interaction.user.name}' requested matches by tournament.")
     session: Session = next(get_session())
     contests = crud.list_contests(session)
     if not contests:
-        await interaction.response.send_message("No tournaments found.", ephemeral=True)
+        await interaction.response.send_message(
+            "No tournaments found.",
+            ephemeral=True,
+        )
         return
 
     view = discord.ui.View(timeout=180)
     view.add_item(TournamentSelect(contests=contests[:25]))
-    await interaction.response.send_message("Please select a tournament:", view=view, ephemeral=True)
+    await interaction.response.send_message(
+        "Please select a tournament:", view=view, ephemeral=True
+    )
 
 
-@matches_group.command(name="upload", description="Upload a match schedule via CSV (Admin only).")
+@matches_group.command(
+    name="upload", description="Upload a match schedule via CSV (Admin only)."
+)
 @app_commands.describe(
     contest_id="The ID of the contest to add matches to.",
     attachment="The CSV file with the match schedule.",
 )
-async def upload(interaction: discord.Interaction, contest_id: int, attachment: discord.Attachment):
+async def upload(
+    interaction: discord.Interaction,
+    contest_id: int,
+    attachment: discord.Attachment,
+):
     """Handles CSV upload for match schedules."""
     if interaction.user.id not in ADMIN_IDS:
-        await interaction.response.send_message("You do not have permission to use this command.", ephemeral=True)
+        await interaction.response.send_message(
+            "You do not have permission to use this command.", ephemeral=True
+        )
         return
 
-    logger.info(f"Admin '{interaction.user.name}' is uploading matches for contest {contest_id}.")
+    logger.info(
+        f"Admin '{interaction.user.name}' is uploading matches for contest "
+        f"{contest_id}."
+    )
     await interaction.response.defer(ephemeral=True)
 
     session: Session = next(get_session())
     contest = crud.get_contest_by_id(session, contest_id)
     if not contest:
-        await interaction.followup.send(f"Contest with ID {contest_id} not found.", ephemeral=True)
+        await interaction.followup.send(
+            f"Contest with ID {contest_id} not found.", ephemeral=True
+        )
         return
 
     try:
@@ -150,25 +200,35 @@ async def upload(interaction: discord.Interaction, contest_id: int, attachment: 
         errors = []
         for i, row in enumerate(reader, 1):
             try:
-                matches_to_create.append({
-                    "contest_id": contest_id,
-                    "team1": row["team1"],
-                    "team2": row["team2"],
-                    "scheduled_time": datetime.fromisoformat(row["scheduled_time"]),
-                })
+                matches_to_create.append(
+                    {
+                        "contest_id": contest_id,
+                        "team1": row["team1"],
+                        "team2": row["team2"],
+                        "scheduled_time": datetime.fromisoformat(row["scheduled_time"]),
+                    }
+                )
             except (KeyError, ValueError) as e:
                 errors.append(f"Row {i+1}: Invalid data or format. {e}")
 
         if errors:
-            await interaction.followup.send("Errors found in CSV:\n" + "\n".join(errors), ephemeral=True)
+            await interaction.followup.send(
+                "Errors found in CSV:\n" + "\n".join(errors), ephemeral=True
+            )
             return
 
         crud.bulk_create_matches(session, matches_to_create)
-        await interaction.followup.send(f"Successfully uploaded {len(matches_to_create)} matches for '{contest.name}'.", ephemeral=True)
+        await interaction.followup.send(
+            f"Successfully uploaded {len(matches_to_create)} matches for "
+            f"'{contest.name}'.",
+            ephemeral=True,
+        )
 
     except Exception as e:
         logger.exception("Error during match upload.")
-        await interaction.followup.send(f"An unexpected error occurred: {e}", ephemeral=True)
+        await interaction.followup.send(
+            f"An unexpected error occurred: {e}", ephemeral=True
+        )
     finally:
         session.close()
 

--- a/src/commands/pick.py
+++ b/src/commands/pick.py
@@ -8,7 +8,7 @@ from discord import app_commands
 from sqlmodel import Session, select
 
 from src.db import get_session
-from src.models import Match, Pick, User
+from src.models import Match, Pick
 from src import crud
 
 logger = logging.getLogger("esports-bot.commands.pick")
@@ -23,10 +23,21 @@ class MatchSelect(discord.ui.Select):
             # Indicate if the user has already picked this match
             picked_indicator = " (✓ Picked)" if match.id in user_picks else ""
             label = f"{match.team1} vs {match.team2}{picked_indicator}"
-            description = f"Scheduled: {match.scheduled_time.strftime('%Y-%m-%d %H:%M UTC')}"
-            options.append(discord.SelectOption(label=label, value=str(match.id), description=description))
+            description = (
+                f"Scheduled: {match.scheduled_time.strftime('%Y-%m-%d %H:%M UTC')}"
+            )
+            options.append(
+                discord.SelectOption(
+                    label=label, value=str(match.id), description=description
+                )
+            )
 
-        super().__init__(placeholder="Choose a match...", min_values=1, max_values=1, options=options)
+        super().__init__(
+            placeholder="Choose a match...",
+            min_values=1,
+            max_values=1,
+            options=options,
+        )
 
     async def callback(self, interaction: discord.Interaction):
         # Defer to allow time for processing
@@ -37,13 +48,19 @@ class MatchSelect(discord.ui.Select):
         match = crud.get_match_by_id(session, match_id)
 
         if not match:
-            await interaction.followup.send("This match could not be found.", ephemeral=True)
+            await interaction.followup.send(
+                "This match could not be found.", ephemeral=True
+            )
             return
 
         # Show the team selection view
         view = discord.ui.View()
         view.add_item(TeamSelect(match=match))
-        await interaction.followup.send(f"You selected: **{match.team1} vs {match.team2}**. Who will win?", view=view, ephemeral=True)
+        await interaction.followup.send(
+            f"You selected: **{match.team1} vs {match.team2}**. Who will win?",
+            view=view,
+            ephemeral=True,
+        )
 
 
 class TeamSelect(discord.ui.Select):
@@ -55,19 +72,33 @@ class TeamSelect(discord.ui.Select):
             discord.SelectOption(label=match.team1, value=match.team1),
             discord.SelectOption(label=match.team2, value=match.team2),
         ]
-        super().__init__(placeholder="Select the winning team...", min_values=1, max_values=1, options=options)
+        super().__init__(
+            placeholder="Select the winning team...",
+            min_values=1,
+            max_values=1,
+            options=options,
+        )
 
     async def callback(self, interaction: discord.Interaction):
         chosen_team = self.values[0]
         session: Session = next(get_session())
 
         # Get or create the user
-        db_user = crud.get_user_by_discord_id(session, str(interaction.user.id))
+        db_user = crud.get_user_by_discord_id(
+            session,
+            str(interaction.user.id),
+        )
         if not db_user:
-            db_user = crud.create_user(session, str(interaction.user.id), interaction.user.name)
+            db_user = crud.create_user(
+                session, str(interaction.user.id), interaction.user.name
+            )
 
         # Check if a pick already exists for this user and match
-        existing_pick_stmt = select(Pick).where(Pick.user_id == db_user.id).where(Pick.match_id == self.match.id)
+        existing_pick_stmt = (
+            select(Pick)
+            .where(Pick.user_id == db_user.id)
+            .where(Pick.match_id == self.match.id)
+        )
         existing_pick = session.exec(existing_pick_stmt).first()
 
         if existing_pick:
@@ -75,7 +106,10 @@ class TeamSelect(discord.ui.Select):
             existing_pick.chosen_team = chosen_team
             session.add(existing_pick)
             session.commit()
-            message = f"Your pick for **{self.match.team1} vs {self.match.team2}** has been updated to **{chosen_team}**."
+            message = (
+                f"Your pick for **{self.match.team1} vs {self.match.team2}** "
+                f"has been updated to **{chosen_team}**."
+            )
         else:
             # Create a new pick
             crud.create_pick(
@@ -85,21 +119,33 @@ class TeamSelect(discord.ui.Select):
                 match_id=self.match.id,
                 chosen_team=chosen_team,
             )
-            message = f"You have picked **{chosen_team}** to win the match: **{self.match.team1} vs {self.match.team2}**."
+            message = (
+                f"You have picked **{chosen_team}** to win the match: "
+                f"**{self.match.team1} vs {self.match.team2}**."
+            )
 
         await interaction.response.send_message(message, ephemeral=True)
         # Remove the view after selection
         await interaction.edit_original_response(view=None)
 
 
-@app_commands.command(name="pick", description="Submit or update a pick for an upcoming match.")
+@app_commands.command(
+    name="pick", description="Submit or update a pick for an upcoming match."
+)
 async def pick(interaction: discord.Interaction):
     """The main command to initiate picking a match."""
-    logger.info(f"'{interaction.user.name}' ({interaction.user.id}) initiated a pick.")
+    logger.info(
+        "'%s' (%s) initiated a pick.",
+        interaction.user.name,
+        interaction.user.id,
+    )
     session: Session = next(get_session())
 
     # Get user and their existing picks
-    db_user = crud.get_user_by_discord_id(session, str(interaction.user.id))
+    db_user = crud.get_user_by_discord_id(
+        session,
+        str(interaction.user.id),
+    )
     user_picks = {}
     if db_user:
         picks = crud.list_picks_for_user(session, db_user.id)
@@ -107,16 +153,24 @@ async def pick(interaction: discord.Interaction):
 
     # Fetch active matches (not yet started)
     now_utc = datetime.now(timezone.utc)
-    active_matches_stmt = select(Match).where(Match.scheduled_time > now_utc).order_by(Match.scheduled_time)
+    active_matches_stmt = (
+        select(Match)
+        .where(Match.scheduled_time > now_utc)
+        .order_by(Match.scheduled_time)
+    )
     active_matches = session.exec(active_matches_stmt).all()
 
     if not active_matches:
-        await interaction.response.send_message("There are no active matches available to pick.", ephemeral=True)
+        await interaction.response.send_message(
+            "There are no active matches available to pick.", ephemeral=True
+        )
         return
 
     view = discord.ui.View()
     view.add_item(MatchSelect(matches=active_matches, user_picks=user_picks))
-    await interaction.response.send_message("Please select a match to place your pick:", view=view, ephemeral=True)
+    await interaction.response.send_message(
+        "Please select a match to place your pick:", view=view, ephemeral=True
+    )
 
 
 async def setup(bot):

--- a/src/commands/picks.py
+++ b/src/commands/picks.py
@@ -13,18 +13,26 @@ from src import crud
 
 logger = logging.getLogger("esports-bot.commands.picks")
 
-picks_group = app_commands.Group(name="picks", description="Commands for viewing picks.")
+picks_group = app_commands.Group(
+    name="picks", description="Commands for viewing picks."
+)
 
 
-@picks_group.command(name="view-active", description="View your active picks for upcoming matches.")
+@picks_group.command(
+    name="view-active", description="View your active picks for upcoming matches."
+)
 async def view_active(interaction: discord.Interaction):
     """Shows a user their own upcoming/active picks."""
-    logger.info(f"'{interaction.user.name}' ({interaction.user.id}) requested their active picks.")
+    logger.info(
+        f"'{interaction.user.name}' ({interaction.user.id}) requested their active picks."
+    )
     session: Session = next(get_session())
 
     db_user = crud.get_user_by_discord_id(session, str(interaction.user.id))
     if not db_user:
-        await interaction.response.send_message("You have no active picks.", ephemeral=True)
+        await interaction.response.send_message(
+            "You have no active picks.", ephemeral=True
+        )
         return
 
     now_utc = datetime.now(timezone.utc)
@@ -39,23 +47,28 @@ async def view_active(interaction: discord.Interaction):
     active_picks = session.exec(active_picks_stmt).all()
 
     if not active_picks:
-        await interaction.response.send_message("You have no active picks.", ephemeral=True)
+        await interaction.response.send_message(
+            "You have no active picks.", ephemeral=True
+        )
         return
 
     embed = discord.Embed(
         title="Your Active Picks",
         color=discord.Color.blue(),
-        timestamp=datetime.now(timezone.utc)
+        timestamp=datetime.now(timezone.utc),
     )
-    embed.set_author(name=interaction.user.display_name, icon_url=interaction.user.avatar.url if interaction.user.avatar else None)
+    embed.set_author(
+        name=interaction.user.display_name,
+        icon_url=interaction.user.avatar.url if interaction.user.avatar else None,
+    )
 
     for pick in active_picks:
         match_info = f"{pick.match.team1} vs {pick.match.team2}"
-        time_str = pick.match.scheduled_time.strftime('%Y-%m-%d %H:%M UTC')
+        time_str = pick.match.scheduled_time.strftime("%Y-%m-%d %H:%M UTC")
         embed.add_field(
             name=match_info,
             value=f"Your pick: **{pick.chosen_team}**\nScheduled: {time_str}",
-            inline=False
+            inline=False,
         )
 
     await interaction.response.send_message(embed=embed, ephemeral=True)
@@ -69,11 +82,13 @@ class MatchSelectForPicks(discord.ui.Select):
             discord.SelectOption(
                 label=f"{match.team1} vs {match.team2}",
                 value=str(match.id),
-                description=f"Scheduled: {match.scheduled_time.strftime('%Y-%m-%d %H:%M UTC')}"
+                description=f"Scheduled: {match.scheduled_time.strftime('%Y-%m-%d %H:%M UTC')}",
             )
             for match in matches
         ]
-        super().__init__(placeholder="Choose a match...", min_values=1, max_values=1, options=options)
+        super().__init__(
+            placeholder="Choose a match...", min_values=1, max_values=1, options=options
+        )
 
     async def callback(self, interaction: discord.Interaction):
         await interaction.response.defer(ephemeral=True, thinking=True)
@@ -90,7 +105,7 @@ class MatchSelectForPicks(discord.ui.Select):
         embed = discord.Embed(
             title=f"Picks for {match.team1} vs {match.team2}",
             color=discord.Color.green(),
-            timestamp=datetime.now(timezone.utc)
+            timestamp=datetime.now(timezone.utc),
         )
 
         if not picks:
@@ -106,29 +121,47 @@ class MatchSelectForPicks(discord.ui.Select):
                     team2_picks.append(user_name)
 
             if team1_picks:
-                embed.add_field(name=f"Picks for {match.team1} ({len(team1_picks)})", value="\n".join(team1_picks), inline=True)
+                embed.add_field(
+                    name=f"Picks for {match.team1} ({len(team1_picks)})",
+                    value="\n".join(team1_picks),
+                    inline=True,
+                )
             if team2_picks:
-                embed.add_field(name=f"Picks for {match.team2} ({len(team2_picks)})", value="\n".join(team2_picks), inline=True)
+                embed.add_field(
+                    name=f"Picks for {match.team2} ({len(team2_picks)})",
+                    value="\n".join(team2_picks),
+                    inline=True,
+                )
 
         await interaction.followup.send(embed=embed, ephemeral=True)
         await interaction.edit_original_response(view=None)
 
 
-@picks_group.command(name="view-match", description="View all picks for a specific match.")
+@picks_group.command(
+    name="view-match", description="View all picks for a specific match."
+)
 async def view_match(interaction: discord.Interaction):
     """Shows all picks for a selected match."""
-    logger.info(f"'{interaction.user.name}' ({interaction.user.id}) requested to view match picks.")
+    logger.info(
+        f"'{interaction.user.name}' ({interaction.user.id}) requested to view match picks."
+    )
     session: Session = next(get_session())
 
     matches = session.exec(select(Match).order_by(Match.scheduled_time)).all()
 
     if not matches:
-        await interaction.response.send_message("There are no matches to view.", ephemeral=True)
+        await interaction.response.send_message(
+            "There are no matches to view.", ephemeral=True
+        )
         return
 
     view = discord.ui.View()
-    view.add_item(MatchSelectForPicks(matches=matches[:25]))  # Limit to 25 options for dropdown
-    await interaction.response.send_message("Please select a match to view the picks:", view=view, ephemeral=True)
+    view.add_item(
+        MatchSelectForPicks(matches=matches[:25])
+    )  # Limit to 25 options for dropdown
+    await interaction.response.send_message(
+        "Please select a match to view the picks:", view=view, ephemeral=True
+    )
 
 
 async def setup(bot):

--- a/src/commands/ping.py
+++ b/src/commands/ping.py
@@ -14,6 +14,5 @@ async def setup(bot):
         # Use bot.latency for websocket heartbeat latency and report ms
         latency_ms = int(bot.latency * 1000) if bot.latency else "unknown"
         await interaction.response.send_message(
-            f"Pong! websocket latency: {latency_ms} ms",
-            ephemeral=True
-            )
+            f"Pong! websocket latency: {latency_ms} ms", ephemeral=True
+        )

--- a/src/commands/stats.py
+++ b/src/commands/stats.py
@@ -15,7 +15,9 @@ from src import crud
 logger = logging.getLogger("esports-bot.commands.stats")
 
 
-@app_commands.command(name="stats", description="View your or another user's pick statistics.")
+@app_commands.command(
+    name="stats", description="View your or another user's pick statistics."
+)
 @app_commands.describe(user="The user to view stats for (defaults to yourself).")
 async def stats(interaction: discord.Interaction, user: discord.Member = None):
     """Displays statistics for a user."""
@@ -26,14 +28,18 @@ async def stats(interaction: discord.Interaction, user: discord.Member = None):
     db_user = crud.get_user_by_discord_id(session, str(target_user.id))
 
     if not db_user:
-        message = "You have not made any picks yet." if not user else f"{target_user.display_name} has not made any picks yet."
+        message = (
+            "You have not made any picks yet."
+            if not user
+            else f"{target_user.display_name} has not made any picks yet."
+        )
         await interaction.response.send_message(message, ephemeral=True)
         return
 
     # Calculate basic stats
     picks = crud.list_picks_for_user(session, db_user.id)
     total_picks = len(picks)
-    correct_picks = len([p for p in picks if p.status == 'correct'])
+    correct_picks = len([p for p in picks if p.status == "correct"])
     win_rate = (correct_picks / total_picks) * 100 if total_picks > 0 else 0
 
     # Calculate global rank
@@ -56,7 +62,7 @@ async def stats(interaction: discord.Interaction, user: discord.Member = None):
     embed = discord.Embed(
         title=f"Statistics for {target_user.display_name}",
         color=discord.Color.gold(),
-        timestamp=datetime.now(timezone.utc)
+        timestamp=datetime.now(timezone.utc),
     )
     embed.set_thumbnail(url=target_user.avatar.url if target_user.avatar else None)
     embed.add_field(name="Total Picks Made", value=str(total_picks), inline=True)

--- a/src/crud.py
+++ b/src/crud.py
@@ -25,9 +25,9 @@ def get_user_by_discord_id(
     return session.exec(statement).first()
 
 
-def update_user(session: Session,
-                user_id: int,
-                username: Optional[str] = None) -> Optional[User]:
+def update_user(
+    session: Session, user_id: int, username: Optional[str] = None
+) -> Optional[User]:
     user = session.get(User, user_id)
     if not user:
         return None
@@ -134,14 +134,14 @@ def bulk_create_matches(session: Session, matches_data: List[dict]) -> List[Matc
 def get_matches_by_date(session: Session, date: datetime) -> List[Match]:
     # Assumes 'date' is the day, returns matches scheduled on that date
     start = datetime(date.year, date.month, date.day, tzinfo=timezone.utc)
-    end = datetime(date.year,
-                   date.month,
-                   date.day, 23, 59, 59, tzinfo=timezone.utc)
-    return list(session.exec(
-        select(Match).where(
-            (Match.scheduled_time >= start) & (Match.scheduled_time <= end)
+    end = datetime(date.year, date.month, date.day, 23, 59, 59, tzinfo=timezone.utc)
+    return list(
+        session.exec(
+            select(Match).where(
+                (Match.scheduled_time >= start) & (Match.scheduled_time <= end)
+            )
         )
-    ))
+    )
 
 
 def list_matches_for_contest(session: Session, contest_id: int) -> List[Match]:

--- a/src/db.py
+++ b/src/db.py
@@ -1,7 +1,9 @@
 from sqlmodel import SQLModel, create_engine, Session
 import os
 
-DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:////opt/esports-bot/data/esports_pickem.db")
+DATABASE_URL = os.getenv(
+    "DATABASE_URL", "sqlite:////opt/esports-bot/data/esports_pickem.db"
+)
 
 # compute the SQL echo flag on its own line to avoid overly long lines
 _sql_echo = os.getenv("SQL_ECHO", "False").lower() in ("true", "1", "t")

--- a/tests/commands/test_contest.py
+++ b/tests/commands/test_contest.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch, ANY
 from src.commands.contest import Contest
 from src.models import Contest as ContestModel
 
+
 @pytest.fixture
 def mock_interaction():
     """Fixture for a mock discord.Interaction."""
@@ -13,6 +14,7 @@ def mock_interaction():
     interaction.user = MagicMock()
     interaction.user.id = 12345
     return interaction
+
 
 @pytest.mark.asyncio
 @patch("src.commands.contest.ContestModal", autospec=True)
@@ -31,14 +33,18 @@ async def test_contest_create_command_sends_modal(mock_contest_modal, mock_inter
         mock_contest_modal.return_value
     )
 
+
 @pytest.mark.asyncio
 @patch("src.commands.contest.create_contest")
 @patch("src.commands.contest.get_session")
 @patch("src.commands.contest.ADMIN_IDS", [12345])
-async def test_contest_modal_on_submit_success(mock_get_session, mock_create_contest, mock_interaction):
+async def test_contest_modal_on_submit_success(
+    mock_get_session, mock_create_contest, mock_interaction
+):
     """Test the ContestModal's on_submit method successfully creates a contest."""
     # Arrange
     from src.commands.contest import ContestModal
+
     modal = ContestModal()
     modal.name = MagicMock()
     modal.name.value = "Test Contest"
@@ -57,10 +63,7 @@ async def test_contest_modal_on_submit_success(mock_get_session, mock_create_con
 
     # Assert
     mock_create_contest.assert_called_once_with(
-        mock_session,
-        name="Test Contest",
-        start_date=ANY,
-        end_date=ANY
+        mock_session, name="Test Contest", start_date=ANY, end_date=ANY
     )
     mock_interaction.response.send_message.assert_called_once_with(
         "Contest 'Test Contest' created with ID 1",

--- a/tests/commands/test_leaderboard.py
+++ b/tests/commands/test_leaderboard.py
@@ -38,8 +38,12 @@ async def test_leaderboard_command_initial_call(
     await leaderboard.callback(mock_interaction)
 
     # Assert
-    mock_get_data.assert_called_once_with(mock_get_session.return_value.__next__.return_value)
-    mock_create_embed.assert_called_once_with("Global Leaderboard", [("user1", 100)], mock_interaction)
+    mock_get_data.assert_called_once_with(
+        mock_get_session.return_value.__next__.return_value
+    )
+    mock_create_embed.assert_called_once_with(
+        "Global Leaderboard", [("user1", 100)], mock_interaction
+    )
     mock_interaction.response.send_message.assert_called_once()
 
     args, kwargs = mock_interaction.response.send_message.call_args
@@ -61,7 +65,8 @@ async def test_leaderboard_view_button_click(
 
     # Simulate clicking the "Server" button
     button_to_click = next(
-        item for item in view.children
+        item
+        for item in view.children
         if isinstance(item, discord.ui.Button) and item.label == "Server"
     )
     assert button_to_click.label == "Server"
@@ -91,7 +96,9 @@ async def test_leaderboard_view_button_click(
         days=None,
         guild_id=mock_interaction.guild.id,
     )
-    mock_create_embed.assert_called_with("Server Leaderboard", [("user2", 200)], mock_interaction)
+    mock_create_embed.assert_called_with(
+        "Server Leaderboard", [("user2", 200)], mock_interaction
+    )
     mock_interaction.edit_original_response.assert_called_once()
 
     args, kwargs = mock_interaction.edit_original_response.call_args

--- a/tests/test_bot_skeleton.py
+++ b/tests/test_bot_skeleton.py
@@ -7,12 +7,14 @@ import inspect
 def test_commands_package_importable():
     """The src.commands package should be importable and have a __path__."""
     import src.commands as commands_pkg
+
     assert hasattr(commands_pkg, "__path__")
 
 
 def test_each_command_module_has_setup():
     """Each command module in src.commands should define a setup() function."""
     import src.commands as commands_pkg
+
     failures = []
     for module_info in pkgutil.iter_modules(commands_pkg.__path__):
         name = module_info.name
@@ -34,6 +36,7 @@ def test_bot_can_instantiate(monkeypatch):
     # Patch env so DISCORD_TOKEN is present
     monkeypatch.setenv("DISCORD_TOKEN", "dummy")
     from src.app import EsportsBot
+
     bot = EsportsBot()
     assert bot is not None
 
@@ -46,6 +49,7 @@ async def test_ping_command_loads(monkeypatch):
     """
     monkeypatch.setenv("DISCORD_TOKEN", "dummy")
     from src.app import EsportsBot
+
     bot = EsportsBot()
     import src.commands.ping as ping_mod
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -13,16 +13,11 @@ VALID_CSV = (
 )
 
 # CSV with a missing column
-INVALID_CSV_MISSING_COLUMN = (
-    "team1,scheduled_time\n"
-    "Team A,2025-01-01T12:00:00\n"
-)
+INVALID_CSV_MISSING_COLUMN = "team1,scheduled_time\n" "Team A,2025-01-01T12:00:00\n"
 
 # CSV with an invalid date format
-INVALID_CSV_BAD_DATE = (
-    "team1,team2,scheduled_time\n"
-    "Team A,Team B,2025/01/01 12:00\n"
-)
+INVALID_CSV_BAD_DATE = "team1,team2,scheduled_time\n" "Team A,Team B,2025/01/01 12:00\n"
+
 
 @pytest.fixture
 def mock_interaction():
@@ -63,7 +58,9 @@ async def test_upload_command_valid_csv(mock_crud, mock_get_session, mock_intera
 
     assert len(matches_data) == 2
     assert matches_data[0]["team1"] == "Team A"
-    assert matches_data[0]["scheduled_time"] == datetime.fromisoformat("2025-01-01T12:00:00")
+    assert matches_data[0]["scheduled_time"] == datetime.fromisoformat(
+        "2025-01-01T12:00:00"
+    )
 
     mock_interaction.followup.send.assert_called_once_with(
         "Successfully uploaded 2 matches for 'Test Contest'.",

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -203,12 +203,8 @@ def test_pick_crud_and_queries_timestamp_default(session: Session):
     assert got is not None and got.chosen_team == "A"
 
     # list for user/match
-    assert [
-        p.id for p in crud.list_picks_for_user(session, user.id)
-    ] == [pick.id]
-    assert [
-        p.id for p in crud.list_picks_for_match(session, match.id)
-    ] == [pick.id]
+    assert [p.id for p in crud.list_picks_for_user(session, user.id)] == [pick.id]
+    assert [p.id for p in crud.list_picks_for_match(session, match.id)] == [pick.id]
 
     # update
     upd = crud.update_pick(session, pick.id, chosen_team="B")


### PR DESCRIPTION
The previous CI workflow was not failing on linting or test errors due to the use of `|| true` and `|| echo`. This change corrects the workflow to ensure that it fails when it should.

- Correctly install development dependencies from `dev-requirements.txt`.
- Add `flake8` and `black` to `dev-requirements.txt`.
- Remove error suppression from `flake8`, `black`, and `pytest` steps in the CI workflow.

