### PR TITLE
fix(sync): enhance match processing with scoreboard result detection

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,97 @@
+# Esports Pick'em Discord Bot
+
+## Project Overview
+
+This project is a Discord bot designed for managing esports pick'em contests. It allows users to predict match outcomes and compete on leaderboards. The bot integrates with the Leaguepedia API to fetch match data and results.
+
+## Architecture & Technologies
+
+- **Language:** Python 3.10+
+- **Framework:** `discord.py` (using `app_commands` for slash commands)
+- **Database:** PostgreSQL (production), SQLite (local dev)
+- **ORM:** `SQLModel` (SQLAlchemy wrapper)
+- **Migrations:** `Alembic`
+- **Scheduling:** `APScheduler`
+- **External API:** Leaguepedia (via `mwclient` likely, wrapped in `leaguepedia_client.py`)
+
+## Key Directories
+
+- `src/`: Main application source code.
+  - `commands/`: Discord slash command implementations.
+  - `models.py`: Database models (SQLModel).
+  - `scheduler.py`: Job scheduling logic (sync, polling).
+  - `leaguepedia_client.py`: Client for fetching data from Leaguepedia.
+- `tests/`: Unit and integration tests (`pytest`).
+- `alembic/`: Database migration scripts.
+
+## Setup & Installation
+
+1. **Prerequisites:**
+
+- Python 3.10+
+- PostgreSQL (optional for local dev, SQLite is supported)
+
+2. **Install Dependencies:**
+
+    ```bash
+    pip install -r requirements.txt
+    ```
+
+3. **Environment Variables:**
+
+Create a `.env` file (see `.env.example`) with:
+
+- `DISCORD_TOKEN`: Your Bot Token.
+- `DATABASE_URL`: Connection string (e.g., `sqlite:///database.db` or `postgresql://...`).
+- `LOG_LEVEL`: `DEBUG`, `INFO`, etc.
+
+4. **Database Setup:**
+
+Initialize the database and run migrations:
+
+```bash
+    python -m alembic upgrade head
+```
+
+## Building and Running
+
+**Start the Bot:**
+Run the bot as a module from the project root:
+
+```bash
+python -m src.app
+```
+
+**Running Tests:**
+Execute the test suite using `pytest`:
+
+```bash
+python -m pytest
+```
+
+## Development Workflow
+
+- **Database Changes:**
+
+If you modify `src/models.py`, generate a new migration:
+
+```bash
+    python -m alembic revision --autogenerate -m "description_of_change"
+    python -m alembic upgrade head
+```
+
+- **Adding Commands:**
+
+Create new command modules in `src/commands/` and ensure they have a `setup(bot)` function. They are automatically loaded in `src/app.py`.
+
+- **Match Lifecycle Logic:**
+The bot synchronizes data in three stages:
+
+1. **Sync (`perform_leaguepedia_sync`)**: Fetches upcoming matches/tournaments every 6 hours.
+2. **Orchestrator (`schedule_live_polling`)**: Checks every minute for matches starting soon and schedules a poller.
+3. **Poller (`poll_live_match_job`)**: Polls for results of a specific live match every 5 minutes until completed.
+
+## Code Style
+
+- Follows standard Python conventions (PEP 8).
+- Use `black` for formatting and `flake8` for linting (implied by `CONTRIBUTING.md`).

--- a/src/commands/sync_leaguepedia.py
+++ b/src/commands/sync_leaguepedia.py
@@ -267,8 +267,9 @@ async def _detect_and_handle_result(match, ctx: SyncContext, match_id: str):
     """
     Inspect `ctx.scoreboard` for `match`. If the series is complete and no
     local `Result` exists, persist the Result using the provided
-    `ctx.db_session` (do NOT commit here) and append the `(match.id, result.id)`
-    tuple to `ctx.notifications` so callers can notify after the outer
+    `ctx.db_session` (do NOT commit here) and append the
+    `(match.id, result.id)` tuple to `ctx.notifications` so callers can
+    notify after the outer
     transaction commits. Errors are logged and do not raise.
     """
     scoreboard = ctx.scoreboard
@@ -385,7 +386,8 @@ async def perform_leaguepedia_sync() -> dict | None:
             await send_result_notification(match_id, result_id)
         except Exception as exc:
             logger.exception(
-                "Failed to send result notification for match %s (result %s, %s)",
+                "Failed to send result notification for match %s "
+                "(result %s, %s)",
                 match_id,
                 result_id,
                 type(exc).__name__,

--- a/src/match_result_utils.py
+++ b/src/match_result_utils.py
@@ -1,0 +1,41 @@
+"""
+Public utilities for match result computation adapted from
+`src.scheduler`. The intent is to provide a stable, non-underscore
+API for other modules (e.g., `src.commands.sync_leaguepedia`) while
+keeping the implementation colocated in `src.scheduler`.
+
+These wrappers delegate to the existing (underscore-prefixed)
+implementations in `src.scheduler`.
+"""
+from typing import Any, Iterable, List, Tuple, Optional
+
+from src import scheduler
+
+
+def filter_relevant_games_from_scoreboard(scoreboard_data: Iterable[dict] | None, match: Any) -> List[dict]:
+    return scheduler._filter_relevant_games_from_scoreboard(scoreboard_data, match)
+
+
+def calculate_team_scores(relevant_games: Iterable[dict], match: Any) -> Tuple[int, int]:
+    return scheduler._calculate_team_scores(relevant_games, match)
+
+
+def determine_winner(team1_score: int, team2_score: int, match: Any) -> Optional[str]:
+    """
+    Public wrapper for `_determine_winner`.
+
+    Parameters:
+        team1_score (int): Number of games won by `match.team1`.
+        team2_score (int): Number of games won by `match.team2`.
+        match (Any): Match-like object containing at least `best_of`,
+            `team1`, and `team2` attributes.
+
+    Returns:
+        Optional[str]: The winning team name if a winner is determined,
+            otherwise `None` when the series is not yet decided.
+    """
+    return scheduler._determine_winner(team1_score, team2_score, match)
+
+
+async def save_result_and_update_picks(session, match, winner, score_str):
+    return await scheduler._save_result_and_update_picks(session, match, winner, score_str)

--- a/src/match_result_utils.py
+++ b/src/match_result_utils.py
@@ -43,10 +43,10 @@ def determine_winner(
         Optional[str]: The winning team name if a winner is determined,
             otherwise `None` when the series is not yet decided.
     """
-    return scheduler._determine_winner(team1_score, team2_score, match)
+    return scheduler.determine_winner(team1_score, team2_score, match)
 
 
 async def save_result_and_update_picks(session, match, winner, score_str):
-    return await scheduler._save_result_and_update_picks(
+    return await scheduler.save_result_and_update_picks(
         session, match, winner, score_str
     )

--- a/src/match_result_utils.py
+++ b/src/match_result_utils.py
@@ -7,20 +7,29 @@ keeping the implementation colocated in `src.scheduler`.
 These wrappers delegate to the existing (underscore-prefixed)
 implementations in `src.scheduler`.
 """
+
 from typing import Any, Iterable, List, Tuple, Optional
 
 from src import scheduler
 
 
-def filter_relevant_games_from_scoreboard(scoreboard_data: Iterable[dict] | None, match: Any) -> List[dict]:
-    return scheduler._filter_relevant_games_from_scoreboard(scoreboard_data, match)
+def filter_relevant_games_from_scoreboard(
+    scoreboard_data: Iterable[dict] | None, match: Any
+) -> List[dict]:
+    return scheduler.filter_relevant_games_from_scoreboard(
+        scoreboard_data, match
+    )
 
 
-def calculate_team_scores(relevant_games: Iterable[dict], match: Any) -> Tuple[int, int]:
-    return scheduler._calculate_team_scores(relevant_games, match)
+def calculate_team_scores(
+    relevant_games: Iterable[dict], match: Any
+) -> Tuple[int, int]:
+    return scheduler.calculate_team_scores(relevant_games, match)
 
 
-def determine_winner(team1_score: int, team2_score: int, match: Any) -> Optional[str]:
+def determine_winner(
+    team1_score: int, team2_score: int, match: Any
+) -> Optional[str]:
     """
     Public wrapper for `_determine_winner`.
 
@@ -38,4 +47,6 @@ def determine_winner(team1_score: int, team2_score: int, match: Any) -> Optional
 
 
 async def save_result_and_update_picks(session, match, winner, score_str):
-    return await scheduler._save_result_and_update_picks(session, match, winner, score_str)
+    return await scheduler._save_result_and_update_picks(
+        session, match, winner, score_str
+    )

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -234,6 +234,14 @@ def _calculate_team_scores(relevant_games, match):
     return team1_score, team2_score
 
 
+def calculate_team_scores(relevant_games, match):
+    """
+    Public wrapper for `_calculate_team_scores` to expose a non-underscore
+    API for external callers.
+    """
+    return _calculate_team_scores(relevant_games, match)
+
+
 def _determine_winner(team1_score, team2_score, match):
     """
     Determine if there's a winner based on the current scores.
@@ -245,6 +253,13 @@ def _determine_winner(team1_score, team2_score, match):
     elif team2_score >= games_to_win:
         return match.team2
     return None
+
+
+def determine_winner(team1_score, team2_score, match):
+    """
+    Public wrapper for `_determine_winner`.
+    """
+    return _determine_winner(team1_score, team2_score, match)
 
 
 async def _save_result_and_update_picks(session, match, winner, score_str):
@@ -286,6 +301,15 @@ async def _save_result_and_update_picks(session, match, winner, score_str):
     logger.info("Updated %d picks for match %s.", updated_count, match.id)
 
     return result
+
+
+async def save_result_and_update_picks(session, match, winner, score_str):
+    """
+    Public async wrapper for `_save_result_and_update_picks`.
+    """
+    return await _save_result_and_update_picks(
+        session, match, winner, score_str
+    )
 
 
 async def _fetch_scoreboard_for_match(match: Match):
@@ -337,6 +361,13 @@ def _filter_relevant_games_from_scoreboard(scoreboard_data, match: Match):
         for g in scoreboard_data
         if {_norm(g.get("Team1")), _norm(g.get("Team2"))} == match_teams
     ]
+
+
+def filter_relevant_games_from_scoreboard(scoreboard_data, match: Match):
+    """
+    Public wrapper for `_filter_relevant_games_from_scoreboard`.
+    """
+    return _filter_relevant_games_from_scoreboard(scoreboard_data, match)
 
 
 async def _handle_winner(

--- a/tests/test_sync_result_detection.py
+++ b/tests/test_sync_result_detection.py
@@ -1,0 +1,118 @@
+import pytest
+from datetime import datetime, timezone, timedelta
+from src.commands import sync_leaguepedia
+from src.models import Match, Contest, Result
+from src.commands.sync_leaguepedia import SyncContext
+from tests.testing_utils import get_test_async_session, setup_test_db, teardown_test_db
+
+
+@pytest.mark.asyncio
+async def test_calculate_match_outcome_basic():
+    # Simple scoreboard where TeamA wins 2-0 in a best_of=3
+    match = type("M", (), {})()
+    match.team1 = "TeamA"
+    match.team2 = "TeamB"
+    match.best_of = 3
+    # Two games, both won by TeamA (Winner 1)
+    scoreboard = [
+        {"Team1": "TeamA", "Team2": "TeamB", "Winner": 1},
+        {"Team1": "TeamA", "Team2": "TeamB", "Winner": 1},
+    ]
+
+    winner, score = sync_leaguepedia._calculate_match_outcome(scoreboard, match)
+    assert winner == "TeamA"
+    assert score == "2-0"
+
+
+@pytest.mark.asyncio
+async def test_persist_match_outcome_and_notifications():
+    await setup_test_db()
+    async with get_test_async_session() as session:
+        # Create contest and match in DB
+        contest = Contest(leaguepedia_id="c1", name="C", start_date=datetime.now(timezone.utc), end_date=(datetime.now(timezone.utc) + timedelta(days=1)))
+        session.add(contest)
+        await session.flush()
+        await session.refresh(contest)
+
+        match = Match(
+            leaguepedia_id="m1",
+            contest_id=contest.id,
+            team1="TeamA",
+            team2="TeamB",
+            best_of=3,
+            scheduled_time=datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+        session.add(match)
+        await session.flush()
+        await session.refresh(match)
+
+        ctx = SyncContext(contest=contest, db_session=session, summary={"contests":0, "matches":0, "teams":0}, scoreboard=None)
+
+        # Persist a result for the match
+        result = await sync_leaguepedia._persist_match_outcome(ctx, match, "TeamA", "2-0")
+
+        # Result should be created and queued in notifications
+        assert result is not None
+        assert len(ctx.notifications) == 1
+        queued_match_id, queued_result_id = ctx.notifications[0]
+        assert queued_match_id == match.id
+        # Verify result exists in DB
+        db_result = await session.get(Result, queued_result_id)
+        assert db_result is not None
+        assert db_result.winner == "TeamA"
+
+    await teardown_test_db()
+
+
+@pytest.mark.asyncio
+async def test_detect_and_handle_result_errors_and_noop():
+    await setup_test_db()
+    async with get_test_async_session() as session:
+        # Create contest and match
+        contest = Contest(leaguepedia_id="c2", name="C2", start_date=datetime.now(timezone.utc), end_date=(datetime.now(timezone.utc) + timedelta(days=1)))
+        session.add(contest)
+        await session.flush()
+        await session.refresh(contest)
+
+        match = Match(
+            leaguepedia_id="m2",
+            contest_id=contest.id,
+            team1="TeamX",
+            team2="TeamY",
+            best_of=3,
+            scheduled_time=datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+        session.add(match)
+        await session.flush()
+        await session.refresh(match)
+
+        # Case: empty scoreboard -> no action
+        ctx = SyncContext(contest=contest, db_session=session, summary={}, scoreboard=[])
+        res = await sync_leaguepedia._detect_and_handle_result(match, ctx, str(match.leaguepedia_id))
+        assert res is None
+        assert ctx.notifications == []
+
+        # Case: scoreboard with no definitive winner -> no action
+        scoreboard = [{"Team1": "TeamX", "Team2": "TeamY", "Winner": None}]
+        ctx.scoreboard = scoreboard
+        res = await sync_leaguepedia._detect_and_handle_result(match, ctx, str(match.leaguepedia_id))
+        assert res is None
+        assert ctx.notifications == []
+
+        # Case: match disappears before persistence -> deletion simulates missing match
+        # Prepare a scoreboard that would produce a winner
+        scoreboard = [
+            {"Team1": "TeamX", "Team2": "TeamY", "Winner": 1},
+            {"Team1": "TeamX", "Team2": "TeamY", "Winner": 1},
+        ]
+        ctx.scoreboard = scoreboard
+
+        # Delete the match before calling detection to simulate disappearance
+        await session.delete(match)
+        await session.flush()
+
+        res = await sync_leaguepedia._detect_and_handle_result(match, ctx, str(match.leaguepedia_id))
+        assert res is None
+        assert ctx.notifications == []
+
+    await teardown_test_db()

--- a/tests/test_sync_result_detection.py
+++ b/tests/test_sync_result_detection.py
@@ -3,7 +3,11 @@ from datetime import datetime, timezone, timedelta
 from src.commands import sync_leaguepedia
 from src.models import Match, Contest, Result
 from src.commands.sync_leaguepedia import SyncContext
-from tests.testing_utils import get_test_async_session, setup_test_db, teardown_test_db
+from tests.testing_utils import (
+    get_test_async_session,
+    setup_test_db,
+    teardown_test_db,
+)
 
 
 @pytest.mark.asyncio
@@ -15,11 +19,21 @@ async def test_calculate_match_outcome_basic():
     match.best_of = 3
     # Two games, both won by TeamA (Winner 1)
     scoreboard = [
-        {"Team1": "TeamA", "Team2": "TeamB", "Winner": 1},
-        {"Team1": "TeamA", "Team2": "TeamB", "Winner": 1},
+        {
+            "Team1": "TeamA",
+            "Team2": "TeamB",
+            "Winner": 1,
+        },
+        {
+            "Team1": "TeamA",
+            "Team2": "TeamB",
+            "Winner": 1,
+        },
     ]
 
-    winner, score = sync_leaguepedia._calculate_match_outcome(scoreboard, match)
+    winner, score = sync_leaguepedia._calculate_match_outcome(
+        scoreboard, match
+    )
     assert winner == "TeamA"
     assert score == "2-0"
 
@@ -29,27 +43,45 @@ async def test_persist_match_outcome_and_notifications():
     await setup_test_db()
     async with get_test_async_session() as session:
         # Create contest and match in DB
-        contest = Contest(leaguepedia_id="c1", name="C", start_date=datetime.now(timezone.utc), end_date=(datetime.now(timezone.utc) + timedelta(days=1)))
+        start = datetime.now(timezone.utc)
+        contest = Contest(
+            leaguepedia_id="c1",
+            name="C",
+            start_date=start,
+            end_date=(start + timedelta(days=1)),
+        )
         session.add(contest)
         await session.flush()
         await session.refresh(contest)
 
+        scheduled = datetime.now(timezone.utc) + timedelta(hours=1)
         match = Match(
             leaguepedia_id="m1",
             contest_id=contest.id,
             team1="TeamA",
             team2="TeamB",
             best_of=3,
-            scheduled_time=datetime.now(timezone.utc) + timedelta(hours=1),
+            scheduled_time=scheduled,
         )
         session.add(match)
         await session.flush()
         await session.refresh(match)
 
-        ctx = SyncContext(contest=contest, db_session=session, summary={"contests":0, "matches":0, "teams":0}, scoreboard=None)
+        ctx = SyncContext(
+            contest=contest,
+            db_session=session,
+            summary={
+                "contests": 0,
+                "matches": 0,
+                "teams": 0,
+            },
+            scoreboard=None,
+        )
 
         # Persist a result for the match
-        result = await sync_leaguepedia._persist_match_outcome(ctx, match, "TeamA", "2-0")
+        result = await sync_leaguepedia._persist_match_outcome(
+            ctx, match, "TeamA", "2-0"
+        )
 
         # Result should be created and queued in notifications
         assert result is not None
@@ -69,41 +101,66 @@ async def test_detect_and_handle_result_errors_and_noop():
     await setup_test_db()
     async with get_test_async_session() as session:
         # Create contest and match
-        contest = Contest(leaguepedia_id="c2", name="C2", start_date=datetime.now(timezone.utc), end_date=(datetime.now(timezone.utc) + timedelta(days=1)))
+        start = datetime.now(timezone.utc)
+        contest = Contest(
+            leaguepedia_id="c2",
+            name="C2",
+            start_date=start,
+            end_date=(start + timedelta(days=1)),
+        )
         session.add(contest)
         await session.flush()
         await session.refresh(contest)
 
+        scheduled = datetime.now(timezone.utc) + timedelta(hours=1)
         match = Match(
             leaguepedia_id="m2",
             contest_id=contest.id,
             team1="TeamX",
             team2="TeamY",
             best_of=3,
-            scheduled_time=datetime.now(timezone.utc) + timedelta(hours=1),
+            scheduled_time=scheduled,
         )
         session.add(match)
         await session.flush()
         await session.refresh(match)
 
         # Case: empty scoreboard -> no action
-        ctx = SyncContext(contest=contest, db_session=session, summary={}, scoreboard=[])
-        res = await sync_leaguepedia._detect_and_handle_result(match, ctx, str(match.leaguepedia_id))
+        ctx = SyncContext(
+            contest=contest,
+            db_session=session,
+            summary={},
+            scoreboard=[],
+        )
+        res = await sync_leaguepedia._detect_and_handle_result(
+            match, ctx, str(match.leaguepedia_id)
+        )
         assert res is None
         assert ctx.notifications == []
 
         # Case: scoreboard with no definitive winner -> no action
         scoreboard = [{"Team1": "TeamX", "Team2": "TeamY", "Winner": None}]
         ctx.scoreboard = scoreboard
-        res = await sync_leaguepedia._detect_and_handle_result(match, ctx, str(match.leaguepedia_id))
+        res = await sync_leaguepedia._detect_and_handle_result(
+            match, ctx, str(match.leaguepedia_id)
+        )
         assert res is None
         assert ctx.notifications == []
 
-        # Case: match disappears before persistence -> deletion simulates missing match
+        # Case: match disappears before persistence ->
+        # deletion simulates missing match
         # Prepare a scoreboard that would produce a winner
         scoreboard = [
-            {"Team1": "TeamX", "Team2": "TeamY", "Winner": 1},
-            {"Team1": "TeamX", "Team2": "TeamY", "Winner": 1},
+            {
+                "Team1": "TeamX",
+                "Team2": "TeamY",
+                "Winner": 1,
+            },
+            {
+                "Team1": "TeamX",
+                "Team2": "TeamY",
+                "Winner": 1,
+            },
         ]
         ctx.scoreboard = scoreboard
 
@@ -111,7 +168,9 @@ async def test_detect_and_handle_result_errors_and_noop():
         await session.delete(match)
         await session.flush()
 
-        res = await sync_leaguepedia._detect_and_handle_result(match, ctx, str(match.leaguepedia_id))
+        res = await sync_leaguepedia._detect_and_handle_result(
+            match, ctx, str(match.leaguepedia_id)
+        )
         assert res is None
         assert ctx.notifications == []
 


### PR DESCRIPTION
# PR title format

[type] Short, descriptive title (e.g. "feat: add /pick command")

## Description

Add the function that when the `/sync-leaguepedia` command is run and it finds a result it runs the correct result functions to properly store and announce it.

## Related issues

N/A

## Checklist

- [x] I have read the CONTRIBUTING.md (or ITERATIONS.md if CONTRIBUTING.md not present)
- [x] Code changes include tests where applicable
- [x] Relevant documentation has been updated (README, ITERATIONS.md)
- [x] CI passes (or changes to CI are documented)

## How to test / QA steps

Run `/sync-leaguepedia` on a situation where a result wasn't handled correctly.

## Size

Select one: XS

## Notes for reviewers

Any special notes reviewers should be aware of (e.g., DB migrations, feature flags)
