### PR TITLE
feat(matches): enhance match embed display with results and add tests

### DIFF
--- a/src/commands/matches.py
+++ b/src/commands/matches.py
@@ -102,9 +102,17 @@ async def create_matches_embed(
     else:
         for match in matches:
             time_str = match.scheduled_time.strftime("%H:%M UTC")
+            value = f"Time: {time_str}\nContest: {match.contest.name}"
+
+            if match.result:
+                score_str = (
+                    f" ({match.result.score})" if match.result.score else ""
+                )
+                value += f"\n**Result: {match.result.winner} won{score_str}**"
+
             embed.add_field(
                 name=f"{match.team1} vs {match.team2}",
-                value=f"Time: {time_str}\nContest: {match.contest.name}",
+                value=value,
                 inline=False,
             )
     return embed

--- a/src/crud.py
+++ b/src/crud.py
@@ -884,6 +884,7 @@ def get_matches_by_date(session: Session, date: datetime) -> List[Match]:
         .where(Match.scheduled_time <= end)
         .where(Match.team1 != "TBD")
         .where(Match.team2 != "TBD")
+        .options(selectinload(Match.result), selectinload(Match.contest))
     )
     return list(session.exec(statement))
 
@@ -895,6 +896,7 @@ def list_matches_for_contest(session: Session, contest_id: int) -> List[Match]:
         .where(Match.contest_id == contest_id)
         .where(Match.team1 != "TBD")
         .where(Match.team2 != "TBD")
+        .options(selectinload(Match.result), selectinload(Match.contest))
     )
     return list(session.exec(stmt))
 

--- a/tests/test_matches_result_display.py
+++ b/tests/test_matches_result_display.py
@@ -46,7 +46,6 @@ async def test_create_matches_embed_with_result():
     # Field 1: With result
     assert embed.fields[1].name == "Team C vs Team D"
     assert "Result: Team C won (2-0)" in embed.fields[1].value
-    assert "**Result: Team C won (2-0)**" in embed.fields[1].value
 
 
 @pytest.mark.asyncio

--- a/tests/test_matches_result_display.py
+++ b/tests/test_matches_result_display.py
@@ -13,22 +13,29 @@ async def test_create_matches_embed_with_result():
     interaction.user.display_name = "TestUser"
     interaction.user.avatar = None
 
-    contest = Contest(name="Test Tournament")
+    # Use MagicMock with `spec` to avoid SQLModel validation/construct
+    contest = MagicMock(spec=Contest)
+    contest.name = "Test Tournament"
 
-    match_no_result = Match(
-        team1="Team A",
-        team2="Team B",
-        scheduled_time=datetime(2025, 12, 26, 12, 0, tzinfo=timezone.utc),
-        contest=contest,
+    match_no_result = MagicMock(spec=Match)
+    match_no_result.team1 = "Team A"
+    match_no_result.team2 = "Team B"
+    match_no_result.scheduled_time = datetime(
+        2025, 12, 26, 12, 0, tzinfo=timezone.utc
     )
+    match_no_result.contest = contest
+    match_no_result.result = None
 
-    match_with_result = Match(
-        team1="Team C",
-        team2="Team D",
-        scheduled_time=datetime(2025, 12, 26, 15, 0, tzinfo=timezone.utc),
-        contest=contest,
+    match_with_result = MagicMock(spec=Match)
+    match_with_result.team1 = "Team C"
+    match_with_result.team2 = "Team D"
+    match_with_result.scheduled_time = datetime(
+        2025, 12, 26, 15, 0, tzinfo=timezone.utc
     )
-    result = Result(winner="Team C", score="2-0")
+    match_with_result.contest = contest
+    result = MagicMock(spec=Result)
+    result.winner = "Team C"
+    result.score = "2-0"
     match_with_result.result = result
 
     matches = [match_no_result, match_with_result]

--- a/tests/test_matches_result_display.py
+++ b/tests/test_matches_result_display.py
@@ -1,0 +1,65 @@
+import pytest
+import discord
+from unittest.mock import MagicMock
+from datetime import datetime, timezone
+from src.commands.matches import create_matches_embed
+from src.models import Match, Contest, Result
+
+
+@pytest.mark.asyncio
+async def test_create_matches_embed_with_result():
+    # Arrange
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.user.display_name = "TestUser"
+    interaction.user.avatar = None
+
+    contest = Contest(name="Test Tournament")
+
+    match_no_result = Match(
+        team1="Team A",
+        team2="Team B",
+        scheduled_time=datetime(2025, 12, 26, 12, 0, tzinfo=timezone.utc),
+        contest=contest,
+    )
+
+    match_with_result = Match(
+        team1="Team C",
+        team2="Team D",
+        scheduled_time=datetime(2025, 12, 26, 15, 0, tzinfo=timezone.utc),
+        contest=contest,
+    )
+    result = Result(winner="Team C", score="2-0")
+    match_with_result.result = result
+
+    matches = [match_no_result, match_with_result]
+
+    # Act
+    embed = await create_matches_embed("Test Matches", matches, interaction)
+
+    # Assert
+    assert len(embed.fields) == 2
+
+    # Field 0: No result
+    assert embed.fields[0].name == "Team A vs Team B"
+    assert "Result" not in embed.fields[0].value
+
+    # Field 1: With result
+    assert embed.fields[1].name == "Team C vs Team D"
+    assert "Result: Team C won (2-0)" in embed.fields[1].value
+    assert "**Result: Team C won (2-0)**" in embed.fields[1].value
+
+
+@pytest.mark.asyncio
+async def test_create_matches_embed_no_matches():
+    # Arrange
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.user.display_name = "TestUser"
+    interaction.user.avatar = None
+    matches = []
+
+    # Act
+    embed = await create_matches_embed("Empty", matches, interaction)
+
+    # Assert
+    assert embed.description == "No matches found."
+    assert len(embed.fields) == 0


### PR DESCRIPTION
# PR title format

[type] Short, descriptive title (e.g. "feat: add /pick command")

## Description

Add results to the embeds of the various `/matches` commands to display the results of matches that have occured.

## Related issues

N/A

## Checklist

- [x] I have read the CONTRIBUTING.md (or ITERATIONS.md if CONTRIBUTING.md not present)
- [x] Code changes include tests where applicable
- [x] Relevant documentation has been updated (README, ITERATIONS.md)
- [x] CI passes (or changes to CI are documented)

## How to test / QA steps

Use any `/matches` command and run tests

## Size

Select one: XS

## Notes for reviewers

Any special notes reviewers should be aware of (e.g., DB migrations, feature flags)
