### PR TITLE
feat(history): add view-history command to display user's past picks

### DIFF
--- a/src/commands/picks.py
+++ b/src/commands/picks.py
@@ -222,8 +222,7 @@ class MatchSelectForPicks(discord.ui.Select):
             team2_picks = []
             for pick in picks:
                 user_name = (
-                    pick.user.username
-                    or f"User ID: {pick.user.discord_id}"
+                    pick.user.username or f"User ID: {pick.user.discord_id}"
                 )
                 if pick.chosen_team == match.team1:
                     team1_picks.append(user_name)
@@ -232,19 +231,13 @@ class MatchSelectForPicks(discord.ui.Select):
 
             if team1_picks:
                 embed.add_field(
-                    name=(
-                        f"Picks for {match.team1} "
-                        f"({len(team1_picks)})"
-                    ),
+                    name=(f"Picks for {match.team1} " f"({len(team1_picks)})"),
                     value="\n".join(team1_picks),
                     inline=True,
                 )
             if team2_picks:
                 embed.add_field(
-                    name=(
-                        f"Picks for {match.team2} "
-                        f"({len(team2_picks)})"
-                    ),
+                    name=(f"Picks for {match.team2} " f"({len(team2_picks)})"),
                     value="\n".join(team2_picks),
                     inline=True,
                 )

--- a/tests/test_picks_history.py
+++ b/tests/test_picks_history.py
@@ -1,0 +1,128 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import datetime, timezone
+
+import discord
+
+from src.commands import picks
+from src.models import Match, Pick, Result, User, Contest
+
+
+@pytest.fixture
+def mock_interaction():
+    interaction = AsyncMock(spec=discord.Interaction)
+    interaction.response = AsyncMock()
+    interaction.followup = AsyncMock()
+    interaction.user = MagicMock(spec=discord.Member)
+    interaction.user.id = 123
+    interaction.user.name = "TestUser"
+    interaction.user.display_name = "TestUser"
+    interaction.user.avatar.url = "http://example.com/avatar.png"
+    return interaction
+
+
+@pytest.fixture
+def mock_session():
+    return MagicMock()
+
+
+@pytest.mark.asyncio
+@patch("src.commands.picks.get_session")
+@patch("src.commands.picks.crud.get_user_by_discord_id")
+async def test_view_history_no_picks(
+    mock_get_user, mock_get_session, mock_interaction, mock_session
+):
+    mock_get_session.return_value = iter([mock_session])
+    mock_get_user.return_value = User(
+        id=1, discord_id="123", username="TestUser"
+    )
+
+    # Mock empty result
+    mock_session.exec.return_value.all.return_value = []
+
+    await picks.view_history.callback(mock_interaction)
+
+    mock_interaction.response.send_message.assert_called_with(
+        "You have no resolved picks.", ephemeral=True
+    )
+
+
+@pytest.mark.asyncio
+@patch("src.commands.picks.get_session")
+@patch("src.commands.picks.crud.get_user_by_discord_id")
+async def test_view_history_with_picks(
+    mock_get_user, mock_get_session, mock_interaction, mock_session
+):
+    mock_get_session.return_value = iter([mock_session])
+    user = User(id=1, discord_id="123", username="TestUser")
+    mock_get_user.return_value = user
+
+    # Create mock data
+    contest = Contest(name="Test Tournament")
+
+    # Match 1: User picked Team A, Team A won (Correct)
+    match1 = Match(
+        team1="Team A",
+        team2="Team B",
+        scheduled_time=datetime(2025, 1, 1, 12, 0, tzinfo=timezone.utc),
+        contest=contest,
+    )
+    result1 = Result(winner="Team A", score="2-0")
+    match1.result = result1
+
+    pick1 = Pick(
+        user_id=user.id,
+        chosen_team="Team A",
+        is_correct=True,
+        status="correct",
+    )
+    pick1.match = match1
+
+    # Match 2: User picked Team C, Team D won (Incorrect)
+    match2 = Match(
+        team1="Team C",
+        team2="Team D",
+        scheduled_time=datetime(2025, 1, 2, 12, 0, tzinfo=timezone.utc),
+        contest=contest,
+    )
+    result2 = Result(winner="Team D", score="1-2")
+    match2.result = result2
+
+    pick2 = Pick(
+        user_id=user.id,
+        chosen_team="Team C",
+        is_correct=False,
+        status="incorrect",
+    )
+    pick2.match = match2
+
+    # Mock session return
+    mock_session.exec.return_value.all.return_value = [
+        pick2,
+        pick1,
+    ]  # Descending order usually
+
+    await picks.view_history.callback(mock_interaction)
+
+    # Verify response
+    assert mock_interaction.response.send_message.called
+    args, kwargs = mock_interaction.response.send_message.call_args
+    embed = kwargs["embed"]
+
+    assert embed.title == "Your Pick History"
+    assert len(embed.fields) == 2
+
+    # Verify content of fields
+    # Field 0 should be Match 2 (most recent)
+    field0 = embed.fields[0]
+    assert "Team C vs Team D" in field0.name
+    assert "Your pick: **Team C**" in field0.value
+    assert "Winner: Team D (1-2)" in field0.value
+    assert "❌ Incorrect" in field0.value
+
+    # Field 1 should be Match 1
+    field1 = embed.fields[1]
+    assert "Team A vs Team B" in field1.name
+    assert "Your pick: **Team A**" in field1.value
+    assert "Winner: Team A (2-0)" in field1.value
+    assert "✅ Correct" in field1.value

--- a/tests/test_picks_history.py
+++ b/tests/test_picks_history.py
@@ -58,20 +58,30 @@ async def test_view_history_with_picks(
     mock_get_user.return_value = user
 
     # Create mock data
-    contest = Contest(name="Test Tournament")
+    contest = Contest(
+        id=1,
+        leaguepedia_id="contest-1",
+        name="Test Tournament",
+        start_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        end_date=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
 
     # Match 1: User picked Team A, Team A won (Correct)
     match1 = Match(
+        id=1,
+        leaguepedia_id="match-1",
+        contest_id=contest.id,
         team1="Team A",
         team2="Team B",
         scheduled_time=datetime(2025, 1, 1, 12, 0, tzinfo=timezone.utc),
-        contest=contest,
     )
-    result1 = Result(winner="Team A", score="2-0")
+    result1 = Result(match_id=match1.id, winner="Team A", score="2-0")
     match1.result = result1
 
     pick1 = Pick(
         user_id=user.id,
+        contest_id=contest.id,
+        match_id=match1.id,
         chosen_team="Team A",
         is_correct=True,
         status="correct",
@@ -80,16 +90,20 @@ async def test_view_history_with_picks(
 
     # Match 2: User picked Team C, Team D won (Incorrect)
     match2 = Match(
+        id=2,
+        leaguepedia_id="match-2",
+        contest_id=contest.id,
         team1="Team C",
         team2="Team D",
         scheduled_time=datetime(2025, 1, 2, 12, 0, tzinfo=timezone.utc),
-        contest=contest,
     )
-    result2 = Result(winner="Team D", score="1-2")
+    result2 = Result(match_id=match2.id, winner="Team D", score="1-2")
     match2.result = result2
 
     pick2 = Pick(
         user_id=user.id,
+        contest_id=contest.id,
+        match_id=match2.id,
         chosen_team="Team C",
         is_correct=False,
         status="incorrect",
@@ -106,7 +120,7 @@ async def test_view_history_with_picks(
 
     # Verify response
     assert mock_interaction.response.send_message.called
-    args, kwargs = mock_interaction.response.send_message.call_args
+    _, kwargs = mock_interaction.response.send_message.call_args
     embed = kwargs["embed"]
 
     assert embed.title == "Your Pick History"


### PR DESCRIPTION
# PR title format

[type] Short, descriptive title (e.g. "feat: add /pick command")

## Description

Add a new command that lets you directly view your previous picks and the results of those picks. These picks shown with this new command will be shown here after they are no longer determined active picks.

## Related issues

N/A

## Checklist

- [x] I have read the CONTRIBUTING.md (or ITERATIONS.md if CONTRIBUTING.md not present)
- [x] Code changes include tests where applicable
- [x] Relevant documentation has been updated (README, ITERATIONS.md)
- [x] CI passes (or changes to CI are documented)

## Size

Select one: S

## Notes for reviewers

Any special notes reviewers should be aware of (e.g., DB migrations, feature flags)
