### PR TITLE
feat: implement PandaScore rate limit tracking and alerting

### DIFF
--- a/RATE_LIMIT_AUDIT.md
+++ b/RATE_LIMIT_AUDIT.md
@@ -1,0 +1,46 @@
+# PandaScore Rate Limit Audit
+
+This document provides an audit of the application's PandaScore API usage as of the current version.
+
+## Key Information
+- **Rate Limit**: 1,000 requests per hour (resets hourly).
+- **Tracking**: Implemented via `PandaScoreClient` using response headers (`X-Rate-Limit-Remaining`).
+- **Warning Threshold**: configured to trigger when remaining requests drop below 200 (20%).
+
+## Scheduled Jobs Analysis
+
+The application uses two main scheduled jobs that consume API requests:
+
+### 1. `perform_pandascore_sync` (Hourly Sync)
+- **Schedule**: Runs every 1 hour (at the top of the hour).
+- **Function**: `src.pandascore_sync.perform_pandascore_sync`
+- **Actions**:
+  - Fetches upcoming matches (Page 1).
+  - Fetches running matches.
+  - Fetches recent past matches.
+- **Request Count**: ~3 requests per execution.
+- **Hourly Impact**: 3 requests.
+
+### 2. `poll_running_matches_job` (Live Polling)
+- **Schedule**: Runs every 1 minute.
+- **Function**: `src.pandascore_polling.poll_running_matches_job`
+- **Actions**:
+  - Fetches current list of running matches to detect starts/finishes and score updates.
+- **Request Count**: 1 request per execution.
+- **Hourly Impact**: 60 requests.
+
+## Total Estimated Usage
+
+| Job | Frequency | Requests/Run | Requests/Hour |
+| :--- | :--- | :--- | :--- |
+| Hourly Sync | 1/hour | ~3 | 3 |
+| Live Polling | 1/minute | 1 | 60 |
+| **Total** | | | **~63** |
+
+**Utilization**: ~6.3% of the 1,000 requests/hour limit.
+
+## Conclusion
+The current usage is well within the rate limits. The system has significant headroom (over 900 requests/hour) to accommodate additional features or increased polling frequency if needed.
+
+## Monitoring
+Automated monitoring is now in place. Developers (admins) will receive a direct message if the remaining rate limit drops below 200 requests.

--- a/tests/test_rate_limit_refactor.py
+++ b/tests/test_rate_limit_refactor.py
@@ -1,0 +1,116 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from src.pandascore_client import PandaScoreClient, RateLimitError
+import asyncio
+from datetime import datetime, timezone, timedelta
+
+
+@pytest.mark.asyncio
+async def test_update_rate_limits():
+    client = PandaScoreClient(api_key="test")
+    headers = {
+        "X-Rate-Limit-Limit": "1000",
+        "X-Rate-Limit-Remaining": "500",
+        "X-Rate-Limit-Reset": "1234567890",
+    }
+    client._update_rate_limits(headers)
+
+    assert client._rate_limit_limit == 1000
+    assert client._rate_limit_remaining == 500
+    assert client._rate_limit_reset == 1234567890
+    assert client._request_count == 500  # Syncs: 1000 - 500
+
+
+@pytest.mark.asyncio
+async def test_update_rate_limits_alt_headers():
+    client = PandaScoreClient(api_key="test")
+    headers = {
+        "RateLimit-Limit": "2000",
+        "RateLimit-Remaining": "100",
+        "RateLimit-Reset": "9999",
+    }
+    client._update_rate_limits(headers)
+
+    assert client._rate_limit_limit == 2000
+    assert client._rate_limit_remaining == 100
+    assert client._request_count == 1900
+
+
+@pytest.mark.asyncio
+async def test_do_request_once_updates_limits():
+    client = PandaScoreClient(api_key="test")
+
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.headers = {
+        "X-Rate-Limit-Remaining": "900",
+        "X-Rate-Limit-Limit": "1000",
+    }
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = {}
+    mock_response.__aenter__.return_value = mock_response
+    mock_response.__aexit__.return_value = None
+
+    mock_session = MagicMock()
+    mock_session.get.return_value = mock_response
+
+    await client._do_request_once(mock_session, "http://test.com")
+
+    assert client._rate_limit_remaining == 900
+    assert client._request_count == 100
+
+
+@pytest.mark.asyncio
+async def test_warning_callback_triggered():
+    client = PandaScoreClient(api_key="test")
+    callback = AsyncMock()
+    client.add_rate_limit_warning_callback(callback)
+
+    # Threshold is 200. Set remaining to 100.
+    headers = {"X-Rate-Limit-Remaining": "100", "X-Rate-Limit-Limit": "1000"}
+
+    client._update_rate_limits(headers)
+
+    # Allow async task to run
+    await asyncio.sleep(0)
+
+    callback.assert_called_once()
+    status = callback.call_args[0][0]
+    assert status["remaining"] == 100
+    assert status["limit"] == 1000
+
+
+@pytest.mark.asyncio
+async def test_warning_callback_throttled():
+    client = PandaScoreClient(api_key="test")
+    callback = AsyncMock()
+    client.add_rate_limit_warning_callback(callback)
+
+    headers = {"X-Rate-Limit-Remaining": "100", "X-Rate-Limit-Limit": "1000"}
+
+    # First trigger
+    client._update_rate_limits(headers)
+    await asyncio.sleep(0)
+    assert callback.call_count == 1
+
+    # Second trigger immediately
+    client._update_rate_limits(headers)
+    await asyncio.sleep(0)
+    assert callback.call_count == 1  # Should not be called again
+
+    # Advance time (hacky, modify _last_warning_time)
+    client._last_warning_time = datetime.now(timezone.utc) - timedelta(hours=2)
+
+    client._update_rate_limits(headers)
+    await asyncio.sleep(0)
+    assert callback.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_check_rate_limit_blocks():
+    client = PandaScoreClient(api_key="test")
+    client._rate_limit_remaining = 0
+    client._rate_limit_reset = 60
+
+    with pytest.raises(RateLimitError):
+        client._check_rate_limit()


### PR DESCRIPTION
- Refactored `PandaScoreClient` to track rate limit headers (`X-Rate-Limit-*`) from API responses.
- Implemented `add_rate_limit_warning_callback` in `PandaScoreClient`.
- Added rate limit warning handler in `src/app.py` to notify admins via DM when remaining requests drop below 200.
- Created `RATE_LIMIT_AUDIT.md` analyzing current API usage (~63 req/hr vs 1000 limit).
- Added comprehensive tests for rate limit logic in `tests/test_rate_limit_refactor.py`.
- Updated `DisabledPandaScoreClient` to match the new interface.

---
*PR created automatically by Jules for task [14771518183553027323](https://jules.google.com/task/14771518183553027323) started by @WxboySuper*