### PR TITLE
⚡ Bolt: Optimize pick fetching in `pick` command

### DIFF
--- a/src/commands/pick.py
+++ b/src/commands/pick.py
@@ -284,16 +284,6 @@ async def pick(interaction: discord.Interaction):
         interaction.user.id,
     )
     with get_session() as session:
-        # Get user and their existing picks
-        db_user = crud.get_user_by_discord_id(
-            session,
-            str(interaction.user.id),
-        )
-        user_picks = {}
-        if db_user:
-            picks = crud.list_picks_for_user(session, db_user.id)
-            user_picks = {pick.match_id: pick.chosen_team for pick in picks}
-
         # Fetch active matches that are within the pick window
         now_utc = datetime.now(timezone.utc)
         pick_cutoff = now_utc + timedelta(days=PICK_WINDOW_DAYS)
@@ -311,6 +301,19 @@ async def pick(interaction: discord.Interaction):
         if not active_matches:
             await _handle_no_matches(interaction, session)
             return
+
+        # Get user and their existing picks for active matches
+        db_user = crud.get_user_by_discord_id(
+            session,
+            str(interaction.user.id),
+        )
+        user_picks = {}
+        if db_user:
+            active_match_ids = [m.id for m in active_matches]
+            picks = crud.get_user_picks_for_matches(
+                session, db_user.id, active_match_ids
+            )
+            user_picks = {pick.match_id: pick.chosen_team for pick in picks}
 
         view = PickView(
             matches=active_matches,

--- a/src/crud/__init__.py
+++ b/src/crud/__init__.py
@@ -50,6 +50,7 @@ from .pick import (  # skipcq: PY-W2000
     update_pick,
     delete_pick,
     get_user_pick_stats,
+    get_user_picks_for_matches,
     PickCreateParams,
 )
 

--- a/src/crud/pick.py
+++ b/src/crud/pick.py
@@ -151,3 +151,28 @@ def get_user_pick_stats(session: Session, user_id: int) -> Tuple[int, int]:
     correct_picks = session.scalar(correct_query) or 0
 
     return total_picks, correct_picks
+
+
+def get_user_picks_for_matches(
+    session: Session, user_id: int, match_ids: List[int]
+) -> List[Pick]:
+    """
+    Fetch picks for a user restricted to a specific list of matches.
+
+    Parameters:
+        session (Session): Database session.
+        user_id (int): The ID of the user.
+        match_ids (List[int]): The IDs of the matches to fetch picks for.
+
+    Returns:
+        List[Pick]: A list of Pick objects for the specified matches.
+    """
+    logger.debug(
+        "Fetching picks for user %s and matches %s", user_id, match_ids
+    )
+    if not match_ids:
+        return []
+    statement = select(Pick).where(
+        Pick.user_id == user_id, Pick.match_id.in_(match_ids)
+    )
+    return list(session.exec(statement))

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -412,7 +412,7 @@ def test_get_user_picks_for_matches(session: Session):
                 team2=f"T{i}B",
                 scheduled_time=base_time,
                 leaguepedia_id=f"m-test-subset-{i}",
-            )
+            ),
         )
         matches.append(m)
 
@@ -425,7 +425,7 @@ def test_get_user_picks_for_matches(session: Session):
                 contest_id=contest.id,
                 match_id=matches[i].id,
                 chosen_team=f"T{i}A",
-            )
+            ),
         )
 
     # Query for match 0 and 1

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -395,3 +395,51 @@ def test_result_crud_and_queries(session: Session):
 def test_result_update_delete_missing(session: Session):
     assert crud.update_result(session, 8888, score="1-0") is None
     assert crud.delete_result(session, 8888) is False
+
+def test_get_user_picks_for_matches(session: Session):
+    user, contest, _ = _mk_user_contest_match(session)
+
+    # Create 3 matches
+    base_time = datetime(2025, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    matches = []
+    for i in range(3):
+        m = crud.create_match(
+            session,
+            crud.MatchCreateParams(
+                contest_id=contest.id,
+                team1=f"T{i}A",
+                team2=f"T{i}B",
+                scheduled_time=base_time,
+                leaguepedia_id=f"m-test-subset-{i}",
+            )
+        )
+        matches.append(m)
+
+    # Create picks for match 0 and 2
+    for i in [0, 2]:
+        crud.create_pick(
+            session,
+            crud.PickCreateParams(
+                user_id=user.id,
+                contest_id=contest.id,
+                match_id=matches[i].id,
+                chosen_team=f"T{i}A",
+            )
+        )
+
+    # Query for match 0 and 1
+    # Should return pick for match 0 only
+    target_match_ids = [matches[0].id, matches[1].id]
+    picks = crud.get_user_picks_for_matches(session, user.id, target_match_ids)
+
+    assert len(picks) == 1
+    assert picks[0].match_id == matches[0].id
+
+    # Query for match 2
+    picks_2 = crud.get_user_picks_for_matches(session, user.id, [matches[2].id])
+    assert len(picks_2) == 1
+    assert picks_2[0].match_id == matches[2].id
+
+    # Query for match 1 (no pick)
+    picks_1 = crud.get_user_picks_for_matches(session, user.id, [matches[1].id])
+    assert len(picks_1) == 0

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -396,6 +396,7 @@ def test_result_update_delete_missing(session: Session):
     assert crud.update_result(session, 8888, score="1-0") is None
     assert crud.delete_result(session, 8888) is False
 
+
 def test_get_user_picks_for_matches(session: Session):
     user, contest, _ = _mk_user_contest_match(session)
 
@@ -436,10 +437,14 @@ def test_get_user_picks_for_matches(session: Session):
     assert picks[0].match_id == matches[0].id
 
     # Query for match 2
-    picks_2 = crud.get_user_picks_for_matches(session, user.id, [matches[2].id])
+    picks_2 = crud.get_user_picks_for_matches(
+        session, user.id, [matches[2].id]
+    )
     assert len(picks_2) == 1
     assert picks_2[0].match_id == matches[2].id
 
     # Query for match 1 (no pick)
-    picks_1 = crud.get_user_picks_for_matches(session, user.id, [matches[1].id])
+    picks_1 = crud.get_user_picks_for_matches(
+        session, user.id, [matches[1].id]
+    )
     assert len(picks_1) == 0


### PR DESCRIPTION
💡 What: Added `get_user_picks_for_matches` to CRUD and used it in the `/pick` command to fetch only relevant picks for active matches.
🎯 Why: The previous implementation fetched *all* of a user's pick history (potentially thousands of records) just to check the status of a few active matches (usually < 10). This caused unnecessary database load and memory usage.
📊 Impact: Reduces fetched rows from O(Total User Picks) to O(Active Matches). For a user with 1000 picks, this is a ~100x reduction in fetched objects for this command.
🔬 Measurement: Verified with `tests/test_crud.py` ensuring the new function correctly filters picks.

---
*PR created automatically by Jules for task [2270236802858162937](https://jules.google.com/task/2270236802858162937) started by @WxboySuper*