### PR TITLE
🎨 Palette: Enhance Leaderboard UX with Emojis and Context-Aware States

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-02-06 - Visual Feedback for Stale States
 **Learning:** In asynchronous interfaces like Discord, messages can become "stale" (e.g., a match starts while the pick menu is open). Relying on error messages after interaction ("Cannot pick: Match started") is frustrating. Proactively disabling UI elements and adding visual indicators (🔒 emoji) prevents the error loop entirely.
 **Action:** When rendering interactive views that depend on time or state, always check the current state and render "disabled/locked" views if the window has passed, rather than just validating on submit.
+
+## 2026-02-17 - Context-Aware UI Disabling
+**Learning:** Users in different contexts (DMs vs Guilds) encounter buttons that only work in one context. Leaving them enabled but returning an error upon click is confusing and adds friction. Disabling them implicitly teaches the user about the feature's constraints and prevents the "error click."
+**Action:** Check context (e.g., `interaction.guild`) in `View.__init__` and preemptively disable invalid options (like "Server" filters in DMs).

--- a/src/commands/leaderboard.py
+++ b/src/commands/leaderboard.py
@@ -570,6 +570,15 @@ class LeaderboardView(discord.ui.View):
         super().__init__(timeout=180)
         self.interaction = interaction
 
+        # Disable "Server" button if not in a guild (DM context)
+        if interaction.guild is None:
+            for item in self.children:
+                if (
+                    isinstance(item, discord.ui.Button)
+                    and item.label == "Server 🏘️"
+                ):
+                    item.disabled = True
+
     async def update_leaderboard(
         self, interaction: discord.Interaction, period: str, days: int = None
     ):
@@ -593,7 +602,7 @@ class LeaderboardView(discord.ui.View):
                 leaderboard to (used for time-windowed leaderboards);
                 when omitted, no time filter is applied.
         """
-        if period == "Server" and interaction.guild is None:
+        if period == "Server 🏘️" and interaction.guild is None:
             await interaction.response.send_message(
                 "The server leaderboard is only available within a server.",
                 ephemeral=True,
@@ -605,7 +614,7 @@ class LeaderboardView(discord.ui.View):
             # Only read guild id if interaction occurred in a guild
             guild_id = (
                 interaction.guild.id
-                if (period == "Server" and interaction.guild is not None)
+                if (period == "Server 🏘️" and interaction.guild is not None)
                 else None
             )
 
@@ -632,29 +641,29 @@ class LeaderboardView(discord.ui.View):
             )
             await interaction.edit_original_response(embed=embed, view=self)
 
-    @discord.ui.button(label="Global", style=discord.ButtonStyle.primary)
+    @discord.ui.button(label="Global 🌎", style=discord.ButtonStyle.primary)
     async def global_leaderboard(
         self, interaction: discord.Interaction, button: discord.ui.Button
     ):
-        await self.update_leaderboard(interaction, "Global")
+        await self.update_leaderboard(interaction, "Global 🌎")
 
-    @discord.ui.button(label="Server", style=discord.ButtonStyle.secondary)
+    @discord.ui.button(label="Server 🏘️", style=discord.ButtonStyle.secondary)
     async def server_leaderboard(
         self, interaction: discord.Interaction, button: discord.ui.Button
     ):
-        await self.update_leaderboard(interaction, "Server")
+        await self.update_leaderboard(interaction, "Server 🏘️")
 
-    @discord.ui.button(label="Weekly", style=discord.ButtonStyle.secondary)
+    @discord.ui.button(label="Weekly 📅", style=discord.ButtonStyle.secondary)
     async def weekly_leaderboard(
         self, interaction: discord.Interaction, button: discord.ui.Button
     ):
-        await self.update_leaderboard(interaction, "Weekly", days=7)
+        await self.update_leaderboard(interaction, "Weekly 📅", days=7)
 
-    @discord.ui.button(label="Daily", style=discord.ButtonStyle.secondary)
+    @discord.ui.button(label="Daily ☀️", style=discord.ButtonStyle.secondary)
     async def daily_leaderboard(
         self, interaction: discord.Interaction, button: discord.ui.Button
     ):
-        await self.update_leaderboard(interaction, "Daily", days=1)
+        await self.update_leaderboard(interaction, "Daily ☀️", days=1)
 
 
 class ContestSelectForLeaderboard(discord.ui.Select):
@@ -702,7 +711,7 @@ async def leaderboard(interaction: discord.Interaction):
         # Default to global view
         data = await get_leaderboard_data(session)
         embed = await create_leaderboard_embed(
-            "Global Leaderboard",
+            "Global 🌎 Leaderboard",
             data,
             interaction,
         )

--- a/tests/commands/test_leaderboard.py
+++ b/tests/commands/test_leaderboard.py
@@ -65,10 +65,12 @@ async def test_leaderboard_view_button_click(
 
     # Simulate clicking the "Server" button
     button_to_click = next(
-        item
+        (item
         for item in view.children
-        if isinstance(item, discord.ui.Button) and item.label == "Server 🏘️"
+        if isinstance(item, discord.ui.Button) and item.label == "Server 🏘️"),
+        None
     )
+    assert button_to_click is not None
     assert button_to_click.label == "Server 🏘️"
 
     # Mock the return values for the update
@@ -117,16 +119,20 @@ async def test_leaderboard_view_dm_context(mock_interaction):
 
     # Assert
     server_button = next(
-        item
+        (item
         for item in view.children
-        if isinstance(item, discord.ui.Button) and item.label == "Server 🏘️"
+        if isinstance(item, discord.ui.Button) and item.label == "Server 🏘️"),
+        None
     )
+    assert server_button is not None
     assert server_button.disabled is True
 
     # Check other buttons are enabled
     global_button = next(
-        item
+        (item
         for item in view.children
-        if isinstance(item, discord.ui.Button) and item.label == "Global 🌎"
+        if isinstance(item, discord.ui.Button) and item.label == "Global 🌎"),
+        None
     )
+    assert global_button is not None
     assert global_button.disabled is False

--- a/tests/commands/test_leaderboard.py
+++ b/tests/commands/test_leaderboard.py
@@ -64,12 +64,12 @@ async def test_leaderboard_view_button_click(
     view = LeaderboardView(mock_interaction)
 
     # Simulate clicking the "Server" button
-    button_to_click = next(
-        (item
+    server_btn_gen = (
+        item
         for item in view.children
-        if isinstance(item, discord.ui.Button) and item.label == "Server 🏘️"),
-        None
+        if isinstance(item, discord.ui.Button) and item.label == "Server 🏘️"
     )
+    button_to_click = next(server_btn_gen, None)
     assert button_to_click is not None
     assert button_to_click.label == "Server 🏘️"
 
@@ -118,21 +118,21 @@ async def test_leaderboard_view_dm_context(mock_interaction):
     view = LeaderboardView(mock_interaction)
 
     # Assert
-    server_button = next(
-        (item
+    server_btn_gen = (
+        item
         for item in view.children
-        if isinstance(item, discord.ui.Button) and item.label == "Server 🏘️"),
-        None
+        if isinstance(item, discord.ui.Button) and item.label == "Server 🏘️"
     )
+    server_button = next(server_btn_gen, None)
     assert server_button is not None
     assert server_button.disabled is True
 
     # Check other buttons are enabled
-    global_button = next(
-        (item
+    global_btn_gen = (
+        item
         for item in view.children
-        if isinstance(item, discord.ui.Button) and item.label == "Global 🌎"),
-        None
+        if isinstance(item, discord.ui.Button) and item.label == "Global 🌎"
     )
+    global_button = next(global_btn_gen, None)
     assert global_button is not None
     assert global_button.disabled is False

--- a/tests/commands/test_leaderboard.py
+++ b/tests/commands/test_leaderboard.py
@@ -5,6 +5,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from src.commands.leaderboard import LeaderboardView, leaderboard
 
 
+def get_button_by_label(view, label):
+    """Helper to find a button in a view by its label."""
+    for item in view.children:
+        if isinstance(item, discord.ui.Button) and item.label == label:
+            return item
+    return None
+
+
 @pytest.fixture
 def mock_interaction():
     """Fixture for a mock discord.Interaction."""
@@ -64,11 +72,7 @@ async def test_leaderboard_view_button_click(
     view = LeaderboardView(mock_interaction)
 
     # Simulate clicking the "Server" button
-    button_to_click = None
-    for item in view.children:
-        if isinstance(item, discord.ui.Button) and item.label == "Server 🏘️":
-            button_to_click = item
-            break
+    button_to_click = get_button_by_label(view, "Server 🏘️")
     assert button_to_click is not None
     assert button_to_click.label == "Server 🏘️"
 
@@ -117,19 +121,11 @@ async def test_leaderboard_view_dm_context(mock_interaction):
     view = LeaderboardView(mock_interaction)
 
     # Assert
-    server_button = None
-    for item in view.children:
-        if isinstance(item, discord.ui.Button) and item.label == "Server 🏘️":
-            server_button = item
-            break
+    server_button = get_button_by_label(view, "Server 🏘️")
     assert server_button is not None
     assert server_button.disabled is True
 
     # Check other buttons are enabled
-    global_button = None
-    for item in view.children:
-        if isinstance(item, discord.ui.Button) and item.label == "Global 🌎":
-            global_button = item
-            break
+    global_button = get_button_by_label(view, "Global 🌎")
     assert global_button is not None
     assert global_button.disabled is False

--- a/tests/commands/test_leaderboard.py
+++ b/tests/commands/test_leaderboard.py
@@ -31,7 +31,7 @@ async def test_leaderboard_command_initial_call(
     """Test the initial call to the /leaderboard command."""
     # Arrange
     mock_get_data.return_value = [("user1", 100)]
-    mock_embed = discord.Embed(title="Global Leaderboard")
+    mock_embed = discord.Embed(title="Global 🌎 Leaderboard")
     mock_create_embed.return_value = mock_embed
 
     # Act
@@ -42,7 +42,7 @@ async def test_leaderboard_command_initial_call(
         mock_get_session.return_value.__enter__.return_value
     )
     mock_create_embed.assert_called_once_with(
-        "Global Leaderboard", [("user1", 100)], mock_interaction
+        "Global 🌎 Leaderboard", [("user1", 100)], mock_interaction
     )
     mock_interaction.response.send_message.assert_called_once()
 
@@ -67,23 +67,23 @@ async def test_leaderboard_view_button_click(
     button_to_click = next(
         item
         for item in view.children
-        if isinstance(item, discord.ui.Button) and item.label == "Server"
+        if isinstance(item, discord.ui.Button) and item.label == "Server 🏘️"
     )
-    assert button_to_click.label == "Server"
+    assert button_to_click.label == "Server 🏘️"
 
     # Mock the return values for the update
     mock_get_data.return_value = [("user2", 200)]
-    mock_embed = discord.Embed(title="Server Leaderboard")
+    mock_embed = discord.Embed(title="Server 🏘️ Leaderboard")
     mock_create_embed.return_value = mock_embed
 
     # Act
-    await view.update_leaderboard(mock_interaction, "Server")
+    await view.update_leaderboard(mock_interaction, "Server 🏘️")
 
     # Assert
     # Check that button styles are updated correctly
     for item in view.children:
         if isinstance(item, discord.ui.Button):
-            if item.label == "Server":
+            if item.label == "Server 🏘️":
                 assert item.style == discord.ButtonStyle.primary
                 assert item.disabled is True
             else:
@@ -97,10 +97,36 @@ async def test_leaderboard_view_button_click(
         guild_id=mock_interaction.guild.id,
     )
     mock_create_embed.assert_called_with(
-        "Server Leaderboard", [("user2", 200)], mock_interaction
+        "Server 🏘️ Leaderboard", [("user2", 200)], mock_interaction
     )
     mock_interaction.edit_original_response.assert_called_once()
 
     args, kwargs = mock_interaction.edit_original_response.call_args
     assert kwargs["embed"] == mock_embed
     assert kwargs["view"] == view
+
+
+@pytest.mark.asyncio
+async def test_leaderboard_view_dm_context(mock_interaction):
+    """Test that the Server button is disabled in DM context (no guild)."""
+    # Arrange
+    mock_interaction.guild = None
+
+    # Act
+    view = LeaderboardView(mock_interaction)
+
+    # Assert
+    server_button = next(
+        item
+        for item in view.children
+        if isinstance(item, discord.ui.Button) and item.label == "Server 🏘️"
+    )
+    assert server_button.disabled is True
+
+    # Check other buttons are enabled
+    global_button = next(
+        item
+        for item in view.children
+        if isinstance(item, discord.ui.Button) and item.label == "Global 🌎"
+    )
+    assert global_button.disabled is False

--- a/tests/commands/test_leaderboard.py
+++ b/tests/commands/test_leaderboard.py
@@ -64,12 +64,11 @@ async def test_leaderboard_view_button_click(
     view = LeaderboardView(mock_interaction)
 
     # Simulate clicking the "Server" button
-    server_btn_gen = (
-        item
-        for item in view.children
-        if isinstance(item, discord.ui.Button) and item.label == "Server 🏘️"
-    )
-    button_to_click = next(server_btn_gen, None)
+    button_to_click = None
+    for item in view.children:
+        if isinstance(item, discord.ui.Button) and item.label == "Server 🏘️":
+            button_to_click = item
+            break
     assert button_to_click is not None
     assert button_to_click.label == "Server 🏘️"
 
@@ -118,21 +117,19 @@ async def test_leaderboard_view_dm_context(mock_interaction):
     view = LeaderboardView(mock_interaction)
 
     # Assert
-    server_btn_gen = (
-        item
-        for item in view.children
-        if isinstance(item, discord.ui.Button) and item.label == "Server 🏘️"
-    )
-    server_button = next(server_btn_gen, None)
+    server_button = None
+    for item in view.children:
+        if isinstance(item, discord.ui.Button) and item.label == "Server 🏘️":
+            server_button = item
+            break
     assert server_button is not None
     assert server_button.disabled is True
 
     # Check other buttons are enabled
-    global_btn_gen = (
-        item
-        for item in view.children
-        if isinstance(item, discord.ui.Button) and item.label == "Global 🌎"
-    )
-    global_button = next(global_btn_gen, None)
+    global_button = None
+    for item in view.children:
+        if isinstance(item, discord.ui.Button) and item.label == "Global 🌎":
+            global_button = item
+            break
     assert global_button is not None
     assert global_button.disabled is False


### PR DESCRIPTION
Improved the User Experience of the /leaderboard command by adding visual cues (emojis) to the navigation buttons and functionally disabling the 'Server' button when it is not applicable (e.g., in Direct Messages). This prevents users from clicking a button that would result in an error message, replacing it with a clear visual indication that the feature is unavailable in the current context. All changes are covered by updated unit tests.

---
*PR created automatically by Jules for task [1897039246000188128](https://jules.google.com/task/1897039246000188128) started by @WxboySuper*