### PR TITLE
feat(config): add feature flags system

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -32,29 +32,6 @@ def _parse_reminder_minutes(env_val: str | None):
 REMINDER_MINUTES = _parse_reminder_minutes(os.getenv("REMINDER_MINUTES"))
 
 
-def _apply_json_flags(env_val: str, default_flags: dict) -> bool:
-    """Try to parse and apply JSON flags. Returns True if successful."""
-    try:
-        user_flags = json.loads(env_val)
-        if not isinstance(user_flags, dict):
-            return False
-
-        # Validate types for known flags
-        for k, v in user_flags.items():
-            if k in default_flags and isinstance(default_flags[k], bool):
-                # Coerce strings 'true'/'false' to bool
-                if isinstance(v, str):
-                    user_flags[k] = v.lower() == "true"
-                elif not isinstance(v, bool):
-                    # Force other types (int 0/1) to bool
-                    user_flags[k] = bool(v)
-
-        default_flags.update(user_flags)
-        return True
-    except json.JSONDecodeError:
-        return False
-
-
 def _parse_feature_flags(env_val: str | None) -> dict:
     """
     Parse feature flags from environment variable
@@ -71,16 +48,26 @@ def _parse_feature_flags(env_val: str | None) -> dict:
         return default_flags
 
     # Try parsing as JSON
-    if _apply_json_flags(env_val, default_flags):
-        return default_flags
+    try:
+        user_flags = json.loads(env_val)
+        if isinstance(user_flags, dict):
+            for k, v in user_flags.items():
+                if k in default_flags:
+                    if isinstance(default_flags[k], bool):
+                        default_flags[k] = str(v).lower() == "true"
+                    else:
+                        default_flags[k] = v
+            return default_flags
+    except json.JSONDecodeError:
+        pass
 
     # Fallback: key=value
     for part in env_val.split(","):
         if "=" in part:
             k, v = part.split("=", 1)
             k = k.strip()
-            v_bool = v.strip().lower() == "true"
-            default_flags[k] = v_bool
+            if k in default_flags:
+                default_flags[k] = v.strip().lower() == "true"
 
     return default_flags
 

--- a/src/config.py
+++ b/src/config.py
@@ -1,4 +1,5 @@
 import os
+import json
 from pathlib import Path
 
 DATA_PATH = Path(os.getenv("DATA_PATH", "data"))
@@ -29,3 +30,38 @@ def _parse_reminder_minutes(env_val: str | None):
 
 
 REMINDER_MINUTES = _parse_reminder_minutes(os.getenv("REMINDER_MINUTES"))
+
+
+def _parse_feature_flags(env_val: str | None) -> dict:
+    """Parse feature flags from environment variable (JSON or KEY=TRUE,KEY2=FALSE)."""
+    default_flags = {
+        "CS2_ENABLED": False,
+        "VALORANT_ENABLED": False,
+        "DOTA2_ENABLED": False,
+        "ROCKET_LEAGUE_ENABLED": False,
+        "USE_REAL_RATE_LIMITS": True,
+    }
+    if not env_val:
+        return default_flags
+
+    # Try parsing as JSON
+    try:
+        user_flags = json.loads(env_val)
+        if isinstance(user_flags, dict):
+            default_flags.update(user_flags)
+            return default_flags
+    except json.JSONDecodeError:
+        pass
+
+    # Fallback: key=value
+    for part in env_val.split(","):
+        if "=" in part:
+            k, v = part.split("=", 1)
+            k = k.strip()
+            v_bool = v.strip().lower() == "true"
+            default_flags[k] = v_bool
+
+    return default_flags
+
+
+FEATURE_FLAGS = _parse_feature_flags(os.getenv("FEATURE_FLAGS"))

--- a/src/config.py
+++ b/src/config.py
@@ -32,12 +32,36 @@ def _parse_reminder_minutes(env_val: str | None):
 REMINDER_MINUTES = _parse_reminder_minutes(os.getenv("REMINDER_MINUTES"))
 
 
+def _apply_json_flags(env_val: str, flags: dict):
+    """Try to parse JSON and update flags dict."""
+    try:
+        user_flags = json.loads(env_val)
+        if isinstance(user_flags, dict):
+            for k, v in user_flags.items():
+                if k in flags:
+                    flags[k] = str(v).lower() == "true"
+            return True
+    except json.JSONDecodeError:
+        pass
+    return False
+
+
+def _apply_csv_flags(env_val: str, flags: dict):
+    """Fallback to comma-separated key=value pairs."""
+    for part in env_val.split(","):
+        if "=" in part:
+            k, v = part.split("=", 1)
+            k = k.strip()
+            if k in flags:
+                flags[k] = v.strip().lower() == "true"
+
+
 def _parse_feature_flags(env_val: str | None) -> dict:
     """
     Parse feature flags from environment variable
     (JSON or KEY=TRUE,KEY2=FALSE).
     """
-    default_flags = {
+    flags = {
         "CS2_ENABLED": False,
         "VALORANT_ENABLED": False,
         "DOTA2_ENABLED": False,
@@ -45,31 +69,12 @@ def _parse_feature_flags(env_val: str | None) -> dict:
         "USE_REAL_RATE_LIMITS": True,
     }
     if not env_val:
-        return default_flags
+        return flags
 
-    # Try parsing as JSON
-    try:
-        user_flags = json.loads(env_val)
-        if isinstance(user_flags, dict):
-            for k, v in user_flags.items():
-                if k in default_flags:
-                    if isinstance(default_flags[k], bool):
-                        default_flags[k] = str(v).lower() == "true"
-                    else:
-                        default_flags[k] = v
-            return default_flags
-    except json.JSONDecodeError:
-        pass
+    if not _apply_json_flags(env_val, flags):
+        _apply_csv_flags(env_val, flags)
 
-    # Fallback: key=value
-    for part in env_val.split(","):
-        if "=" in part:
-            k, v = part.split("=", 1)
-            k = k.strip()
-            if k in default_flags:
-                default_flags[k] = v.strip().lower() == "true"
-
-    return default_flags
+    return flags
 
 
 FEATURE_FLAGS = _parse_feature_flags(os.getenv("FEATURE_FLAGS"))

--- a/src/config.py
+++ b/src/config.py
@@ -48,6 +48,16 @@ def _parse_feature_flags(env_val: str | None) -> dict:
     try:
         user_flags = json.loads(env_val)
         if isinstance(user_flags, dict):
+            # Validate types for known flags
+            for k, v in user_flags.items():
+                if k in default_flags and isinstance(default_flags[k], bool):
+                    # Coerce strings 'true'/'false' to bool
+                    if isinstance(v, str):
+                        user_flags[k] = v.lower() == "true"
+                    elif not isinstance(v, bool):
+                        # Force other types (int 0/1) to bool
+                        user_flags[k] = bool(v)
+            
             default_flags.update(user_flags)
             return default_flags
     except json.JSONDecodeError:

--- a/src/config.py
+++ b/src/config.py
@@ -32,6 +32,29 @@ def _parse_reminder_minutes(env_val: str | None):
 REMINDER_MINUTES = _parse_reminder_minutes(os.getenv("REMINDER_MINUTES"))
 
 
+def _apply_json_flags(env_val: str, default_flags: dict) -> bool:
+    """Try to parse and apply JSON flags. Returns True if successful."""
+    try:
+        user_flags = json.loads(env_val)
+        if not isinstance(user_flags, dict):
+            return False
+            
+        # Validate types for known flags
+        for k, v in user_flags.items():
+            if k in default_flags and isinstance(default_flags[k], bool):
+                # Coerce strings 'true'/'false' to bool
+                if isinstance(v, str):
+                    user_flags[k] = v.lower() == "true"
+                elif not isinstance(v, bool):
+                    # Force other types (int 0/1) to bool
+                    user_flags[k] = bool(v)
+        
+        default_flags.update(user_flags)
+        return True
+    except json.JSONDecodeError:
+        return False
+
+
 def _parse_feature_flags(env_val: str | None) -> dict:
     """Parse feature flags from environment variable (JSON or KEY=TRUE,KEY2=FALSE)."""
     default_flags = {
@@ -45,23 +68,8 @@ def _parse_feature_flags(env_val: str | None) -> dict:
         return default_flags
 
     # Try parsing as JSON
-    try:
-        user_flags = json.loads(env_val)
-        if isinstance(user_flags, dict):
-            # Validate types for known flags
-            for k, v in user_flags.items():
-                if k in default_flags and isinstance(default_flags[k], bool):
-                    # Coerce strings 'true'/'false' to bool
-                    if isinstance(v, str):
-                        user_flags[k] = v.lower() == "true"
-                    elif not isinstance(v, bool):
-                        # Force other types (int 0/1) to bool
-                        user_flags[k] = bool(v)
-            
-            default_flags.update(user_flags)
-            return default_flags
-    except json.JSONDecodeError:
-        pass
+    if _apply_json_flags(env_val, default_flags):
+        return default_flags
 
     # Fallback: key=value
     for part in env_val.split(","):

--- a/src/config.py
+++ b/src/config.py
@@ -38,7 +38,7 @@ def _apply_json_flags(env_val: str, default_flags: dict) -> bool:
         user_flags = json.loads(env_val)
         if not isinstance(user_flags, dict):
             return False
-            
+
         # Validate types for known flags
         for k, v in user_flags.items():
             if k in default_flags and isinstance(default_flags[k], bool):
@@ -48,7 +48,7 @@ def _apply_json_flags(env_val: str, default_flags: dict) -> bool:
                 elif not isinstance(v, bool):
                     # Force other types (int 0/1) to bool
                     user_flags[k] = bool(v)
-        
+
         default_flags.update(user_flags)
         return True
     except json.JSONDecodeError:
@@ -56,7 +56,10 @@ def _apply_json_flags(env_val: str, default_flags: dict) -> bool:
 
 
 def _parse_feature_flags(env_val: str | None) -> dict:
-    """Parse feature flags from environment variable (JSON or KEY=TRUE,KEY2=FALSE)."""
+    """
+    Parse feature flags from environment variable
+    (JSON or KEY=TRUE,KEY2=FALSE).
+    """
     default_flags = {
         "CS2_ENABLED": False,
         "VALORANT_ENABLED": False,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,56 @@
+from src.config import _parse_feature_flags
+
+
+def test_parse_feature_flags_none():
+    flags = _parse_feature_flags(None)
+    assert flags["CS2_ENABLED"] is False
+    assert flags["USE_REAL_RATE_LIMITS"] is True
+
+
+def test_parse_feature_flags_json_valid():
+    val = '{"CS2_ENABLED": true, "VALORANT_ENABLED": false}'
+    flags = _parse_feature_flags(val)
+    assert flags["CS2_ENABLED"] is True
+    assert flags["VALORANT_ENABLED"] is False
+
+
+def test_parse_feature_flags_json_coerce():
+    val = '{"CS2_ENABLED": "true", "DOTA2_ENABLED": 1}'
+    flags = _parse_feature_flags(val)
+    assert flags["CS2_ENABLED"] is True
+    # "1".lower() == "true" is False
+    assert flags["DOTA2_ENABLED"] is False
+
+
+def test_parse_feature_flags_json_null_safety():
+    val = '{"CS2_ENABLED": null}'
+    flags = _parse_feature_flags(val)
+    assert flags["CS2_ENABLED"] is False
+
+
+def test_parse_feature_flags_json_unknown_ignored():
+    val = '{"UNKNOWN_FLAG": true, "CS2_ENABLED": true}'
+    flags = _parse_feature_flags(val)
+    assert "UNKNOWN_FLAG" not in flags
+    assert flags["CS2_ENABLED"] is True
+
+
+def test_parse_feature_flags_csv_valid():
+    val = "CS2_ENABLED=true,VALORANT_ENABLED=false"
+    flags = _parse_feature_flags(val)
+    assert flags["CS2_ENABLED"] is True
+    assert flags["VALORANT_ENABLED"] is False
+
+
+def test_parse_feature_flags_csv_malformed():
+    val = "CS2_ENABLED,VALORANT_ENABLED=true,=true"
+    flags = _parse_feature_flags(val)
+    assert flags["CS2_ENABLED"] is False
+    assert flags["VALORANT_ENABLED"] is True
+
+
+def test_parse_feature_flags_csv_unknown_ignored():
+    val = "UNKNOWN=true,CS2_ENABLED=true"
+    flags = _parse_feature_flags(val)
+    assert "UNKNOWN" not in flags
+    assert flags["CS2_ENABLED"] is True


### PR DESCRIPTION
## Feature Flags Implementation

This PR introduces a robust feature flag system to src/config.py, enabling safer rollouts and simpler configuration management.

### Key Changes
- **FEATURE_FLAGS Dictionary:** A central configuration object derived from environment variables.
- **Parsing Logic:** Supports FEATURE_FLAGS as a JSON string OR a comma-separated key=value list (e.g., CS2_ENABLED=true,USE_REAL_RATE_LIMITS=false) for ease of use in different environments (.env, docker, etc.).
- **Defaults:**
  - CS2_ENABLED: False
  - VALORANT_ENABLED: False
  - DOTA2_ENABLED: False
  - ROCKET_LEAGUE_ENABLED: False
  - USE_REAL_RATE_LIMITS: True

### Why?
This is a prerequisite for the v1.2 Roadmap, allowing us to merge incomplete game support (like CS2) behind a flag without affecting production stability.