### PR TITLE
fix: merge v1.2 alembic heads

### DIFF
--- a/alembic/versions/c1d2e3f4a5b6_merge_v12_heads.py
+++ b/alembic/versions/c1d2e3f4a5b6_merge_v12_heads.py
@@ -7,7 +7,6 @@ Create Date: 2026-03-13
 
 from typing import Sequence, Union
 
-
 revision: str = "c1d2e3f4a5b6"
 down_revision: Union[str, Sequence[str], None] = (
     "549c0b6c69a6",

--- a/alembic/versions/c1d2e3f4a5b6_merge_v12_heads.py
+++ b/alembic/versions/c1d2e3f4a5b6_merge_v12_heads.py
@@ -5,10 +5,10 @@ Revises: 549c0b6c69a6, 6f9f9a8b7c6d
 Create Date: 2026-03-13
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
 revision: str = "c1d2e3f4a5b6"
-down_revision: Union[str, Sequence[str], None] = (
+down_revision: str | Sequence[str] | None = (
     "549c0b6c69a6",
     "6f9f9a8b7c6d",
 )

--- a/alembic/versions/c1d2e3f4a5b6_merge_v12_heads.py
+++ b/alembic/versions/c1d2e3f4a5b6_merge_v12_heads.py
@@ -1,0 +1,25 @@
+"""Merge v1.2 Alembic heads.
+
+Revision ID: c1d2e3f4a5b6
+Revises: 549c0b6c69a6, 6f9f9a8b7c6d
+Create Date: 2026-03-13
+"""
+
+from typing import Sequence, Union
+
+
+revision: str = "c1d2e3f4a5b6"
+down_revision: Union[str, Sequence[str], None] = (
+    "549c0b6c69a6",
+    "6f9f9a8b7c6d",
+)
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Merge the v1.2 migration branches."""
+
+
+def downgrade() -> None:
+    """Split the v1.2 migration branches."""


### PR DESCRIPTION
## Summary
- add a no-op Alembic merge migration for the two v1.2 heads
- resolve the deployment failure caused by lembic upgrade head seeing multiple heads
- keep existing upgrade paths intact for databases on either branch

## Verification
- python -m alembic heads now reports a single head: c1d2e3f4a5b6
- lake8 alembic/versions/c1d2e3f4a5b6_merge_v12_heads.py
