### PR TITLE
fix: restore multi-game live sync behavior

### DIFF
--- a/src/commands/config.py
+++ b/src/commands/config.py
@@ -58,7 +58,9 @@ def _filter_supported_games(raw_games: Iterable[str]) -> list[str]:
     seen = set()
     for raw in raw_games:
         game = raw.strip().lower()
-        if not game or game in seen or game not in supported:
+        if not game or game in seen:
+            continue
+        if game not in supported:
             continue
         seen.add(game)
         normalized.append(game)

--- a/src/commands/config.py
+++ b/src/commands/config.py
@@ -1,13 +1,7 @@
-"""Guild configuration commands: view / set channels / set games
-
-Provides a minimal `/config` command group so guild admins can view and
-update persisted `GuildConfig` fields such as announcement/live channel IDs
-and enabled games (comma-separated slugs). Permission checks allow guild
-owners or members with `manage_guild`, falling back to the environment
-`ADMIN_IDS` list via `is_admin()`.
-"""
+"""Guild configuration commands: view / set channels / set games."""
 
 import logging
+from typing import Optional
 
 import discord
 from discord import app_commands
@@ -16,6 +10,8 @@ from discord.ext import commands
 from src.auth import is_admin
 from src.crud import get_guild_config_async, upsert_guild_config_async
 from src.db import get_async_session
+from src.live_messages import format_enabled_games
+from src.parsers.factory import get_supported_game_slugs
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +19,21 @@ logger = logging.getLogger(__name__)
 config_group = app_commands.Group(
     name="config", description="Manage guild configuration"
 )
+
+CHANNEL_KIND_CHOICES = [
+    app_commands.Choice(name="Announcement", value="announcement"),
+    app_commands.Choice(name="Live Updates", value="live_updates"),
+]
+
+
+def _format_channel(channel_id: Optional[int]) -> str:
+    if not channel_id:
+        return "(not set)"
+    return f"<#{channel_id}>"
+
+
+def _supported_games_text() -> str:
+    return ", ".join(game.upper() for game in get_supported_game_slugs())
 
 
 @config_group.command(
@@ -37,19 +48,14 @@ async def view(interaction: discord.Interaction):
 
     async with get_async_session() as session:
         cfg = await get_guild_config_async(session, interaction.guild.id)
-        if not cfg:
-            await interaction.response.send_message(
-                "No configuration found for this guild.", ephemeral=True
-            )
-            return
-
-        enabled = cfg.enabled_games or "(none)"
-        ann = cfg.announcement_channel_id or "(none)"
-        live = cfg.live_updates_channel_id or "(none)"
+        enabled = format_enabled_games(getattr(cfg, "enabled_games", None))
+        ann = _format_channel(getattr(cfg, "announcement_channel_id", None))
+        live = _format_channel(getattr(cfg, "live_updates_channel_id", None))
         message = (
             f"Announcement channel: {ann}\n"
             f"Live updates channel: {live}\n"
-            f"Enabled games: {enabled}"
+            f"Enabled games: {enabled}\n"
+            f"Supported games: {_supported_games_text()}"
         )
         await interaction.response.send_message(message, ephemeral=True)
 
@@ -110,12 +116,15 @@ async def _update_guild_channel(guild_id: int, field: str, value: int) -> None:
 @config_group.command(
     name="set_channel", description="Set announcement or live updates channel"
 )
+@app_commands.choices(kind=CHANNEL_KIND_CHOICES)
 @app_commands.describe(
-    kind="Which channel to set: announcement or live",
+    kind="Which channel setting to update",
     channel="Text channel to use",
 )
 async def set_channel(
-    interaction: discord.Interaction, kind: str, channel: discord.TextChannel
+    interaction: discord.Interaction,
+    kind: app_commands.Choice[str],
+    channel: discord.TextChannel,
 ):
     # Permission check
     if not await _has_config_permission(interaction):
@@ -129,13 +138,15 @@ async def set_channel(
         )
         return
 
-    if kind.lower() in ("announcement", "announce"):
+    if kind.value == "announcement":
         field = "announcement_channel_id"
-    elif kind.lower() in ("live", "live_updates"):
+        label = "announcement"
+    elif kind.value == "live_updates":
         field = "live_updates_channel_id"
+        label = "live updates"
     else:
         await interaction.followup.send(
-            "Unknown channel kind. Use 'announcement' or 'live'.",
+            "Unknown channel kind selected.",
             ephemeral=True,
         )
         return
@@ -143,7 +154,8 @@ async def set_channel(
     try:
         await _update_guild_channel(guild_id, field, channel.id)
         await interaction.followup.send(
-            "Configuration updated.", ephemeral=True
+            f"Updated {label} channel to {channel.mention}.",
+            ephemeral=True,
         )
     except Exception:
         logger.exception("Failed updating guild config for %s", guild_id)
@@ -169,22 +181,78 @@ async def set_games(interaction: discord.Interaction, games: str):
         )
         return
 
-    normalized = ",".join(
-        [g.strip().lower() for g in games.split(",") if g.strip()]
-    )
+    normalized = _normalize_games_value(games)
+    if normalized is None:
+        await interaction.followup.send(
+            "Invalid games list. Use supported slugs: "
+            f"{_supported_games_text()}",
+            ephemeral=True,
+        )
+        return
+
     try:
         async with get_async_session() as session:
             await upsert_guild_config_async(
                 session, guild_id, enabled_games=normalized
             )
         await interaction.followup.send(
-            f"Enabled games set to: {normalized}", ephemeral=True
+            f"Enabled games set to: {format_enabled_games(normalized)}",
+            ephemeral=True,
         )
     except Exception:
         logger.exception("Failed updating enabled_games for %s", guild_id)
         await interaction.followup.send(
             "Failed to update enabled games.", ephemeral=True
         )
+
+
+def _normalize_games_value(raw_games: str) -> Optional[str]:
+    supported = set(get_supported_game_slugs())
+    normalized = []
+    seen = set()
+    for raw in raw_games.split(","):
+        game = raw.strip().lower()
+        if not game:
+            continue
+        if game not in supported:
+            return None
+        if game in seen:
+            continue
+        seen.add(game)
+        normalized.append(game)
+
+    if not normalized:
+        return None
+    return ",".join(normalized)
+
+
+@set_games.autocomplete("games")
+async def _games_autocomplete(
+    interaction: discord.Interaction, current: str
+) -> list[app_commands.Choice[str]]:
+    _ = interaction
+    supported = list(get_supported_game_slugs())
+    entries = [item.strip() for item in current.split(",")]
+    prefix = ",".join(entry for entry in entries[:-1] if entry)
+    current_token = entries[-1].strip().lower() if entries else ""
+    already_selected = {
+        entry.strip().lower() for entry in entries[:-1] if entry
+    }
+
+    choices = []
+    for game in supported:
+        if game in already_selected:
+            continue
+        if current_token and not game.startswith(current_token):
+            continue
+        value = f"{prefix},{game}" if prefix else game
+        choices.append(
+            app_commands.Choice(
+                name=format_enabled_games(game),
+                value=value,
+            )
+        )
+    return choices[:25]
 
 
 async def setup(bot: commands.Bot):

--- a/src/commands/config.py
+++ b/src/commands/config.py
@@ -1,6 +1,7 @@
-"""Guild configuration commands: view / set channels / set games."""
+"""Guild configuration commands: view / set channels / manage games."""
 
 import logging
+from collections.abc import Iterable
 from typing import Optional
 
 import discord
@@ -34,6 +35,28 @@ def _format_channel(channel_id: Optional[int]) -> str:
 
 def _supported_games_text() -> str:
     return ", ".join(game.upper() for game in get_supported_game_slugs())
+
+
+def _normalize_games_list(raw_games: Iterable[str]) -> list[str]:
+    supported = set(get_supported_game_slugs())
+    normalized = []
+    seen = set()
+    for raw in raw_games:
+        game = raw.strip().lower()
+        if not game or game in seen:
+            continue
+        if game not in supported:
+            raise ValueError(game)
+        seen.add(game)
+        normalized.append(game)
+    return normalized
+
+
+def _serialize_games(games: Iterable[str]) -> Optional[str]:
+    normalized = _normalize_games_list(games)
+    if not normalized:
+        return None
+    return ",".join(normalized)
 
 
 @config_group.command(
@@ -166,7 +189,7 @@ async def set_channel(
 
 @config_group.command(
     name="set_games",
-    description="Enable comma-separated game slugs (e.g. 'lol,cs2')",
+    description="Replace enabled games with a comma-separated list",
 )
 async def set_games(interaction: discord.Interaction, games: str):
     # Permission check (same as other commands)
@@ -181,11 +204,19 @@ async def set_games(interaction: discord.Interaction, games: str):
         )
         return
 
-    normalized = _normalize_games_value(games)
-    if normalized is None:
+    try:
+        normalized = _serialize_games(games.split(","))
+    except ValueError:
         await interaction.followup.send(
             "Invalid games list. Use supported slugs: "
             f"{_supported_games_text()}",
+            ephemeral=True,
+        )
+        return
+
+    if normalized is None:
+        await interaction.followup.send(
+            "Choose at least one supported game.",
             ephemeral=True,
         )
         return
@@ -206,24 +237,110 @@ async def set_games(interaction: discord.Interaction, games: str):
         )
 
 
-def _normalize_games_value(raw_games: str) -> Optional[str]:
-    supported = set(get_supported_game_slugs())
-    normalized = []
-    seen = set()
-    for raw in raw_games.split(","):
-        game = raw.strip().lower()
-        if not game:
-            continue
-        if game not in supported:
-            return None
-        if game in seen:
-            continue
-        seen.add(game)
-        normalized.append(game)
+async def _load_enabled_games(guild_id: int) -> list[str]:
+    async with get_async_session() as session:
+        cfg = await get_guild_config_async(session, guild_id)
+        raw_games = getattr(cfg, "enabled_games", None)
+    return _normalize_games_list((raw_games or "").split(","))
 
-    if not normalized:
-        return None
-    return ",".join(normalized)
+
+async def _update_enabled_games(
+    guild_id: int,
+    games: Iterable[str],
+) -> str:
+    normalized = _serialize_games(games)
+    async with get_async_session() as session:
+        await upsert_guild_config_async(
+            session, guild_id, enabled_games=normalized
+        )
+    return normalized or ""
+
+
+@config_group.command(
+    name="add_game",
+    description="Enable one supported game for this guild",
+)
+@app_commands.describe(game="Game to enable")
+async def add_game(interaction: discord.Interaction, game: str):
+    if not await _has_config_permission(interaction):
+        return
+
+    await interaction.response.defer(ephemeral=True)
+    guild_id = interaction.guild.id if interaction.guild else None
+    if guild_id is None:
+        await interaction.followup.send(
+            "This command must be run in a server.", ephemeral=True
+        )
+        return
+
+    try:
+        enabled_games = await _load_enabled_games(guild_id)
+        normalized = _normalize_games_list([*enabled_games, game])
+    except ValueError:
+        await interaction.followup.send(
+            "Unsupported game. Choose from: " f"{_supported_games_text()}",
+            ephemeral=True,
+        )
+        return
+
+    if game.strip().lower() in enabled_games:
+        await interaction.followup.send(
+            f"{format_enabled_games(game)} is already enabled.",
+            ephemeral=True,
+        )
+        return
+
+    stored = await _update_enabled_games(guild_id, normalized)
+    await interaction.followup.send(
+        f"Enabled games: {format_enabled_games(stored)}",
+        ephemeral=True,
+    )
+
+
+@config_group.command(
+    name="remove_game",
+    description="Disable one supported game for this guild",
+)
+@app_commands.describe(game="Game to disable")
+async def remove_game(interaction: discord.Interaction, game: str):
+    if not await _has_config_permission(interaction):
+        return
+
+    await interaction.response.defer(ephemeral=True)
+    guild_id = interaction.guild.id if interaction.guild else None
+    if guild_id is None:
+        await interaction.followup.send(
+            "This command must be run in a server.", ephemeral=True
+        )
+        return
+
+    enabled_games = await _load_enabled_games(guild_id)
+    normalized_game = game.strip().lower()
+    if normalized_game not in get_supported_game_slugs():
+        await interaction.followup.send(
+            "Unsupported game. Choose from: " f"{_supported_games_text()}",
+            ephemeral=True,
+        )
+        return
+
+    if normalized_game not in enabled_games:
+        await interaction.followup.send(
+            f"{format_enabled_games(game)} is not enabled.",
+            ephemeral=True,
+        )
+        return
+
+    remaining_games = [
+        enabled_game
+        for enabled_game in enabled_games
+        if enabled_game != normalized_game
+    ]
+    stored = await _update_enabled_games(guild_id, remaining_games)
+    if stored:
+        message = f"Enabled games: {format_enabled_games(stored)}"
+    else:
+        message = "No games are currently enabled for this guild."
+    await interaction.followup.send(message, ephemeral=True)
 
 
 @set_games.autocomplete("games")
@@ -253,6 +370,39 @@ async def _games_autocomplete(
             )
         )
     return choices[:25]
+
+
+async def _single_game_autocomplete(
+    current: str,
+) -> list[app_commands.Choice[str]]:
+    token = current.strip().lower()
+    choices = []
+    for game in get_supported_game_slugs():
+        if token and not game.startswith(token):
+            continue
+        choices.append(
+            app_commands.Choice(
+                name=format_enabled_games(game),
+                value=game,
+            )
+        )
+    return choices[:25]
+
+
+@add_game.autocomplete("game")
+async def _add_game_autocomplete(
+    interaction: discord.Interaction, current: str
+) -> list[app_commands.Choice[str]]:
+    _ = interaction
+    return await _single_game_autocomplete(current)
+
+
+@remove_game.autocomplete("game")
+async def _remove_game_autocomplete(
+    interaction: discord.Interaction, current: str
+) -> list[app_commands.Choice[str]]:
+    _ = interaction
+    return await _single_game_autocomplete(current)
 
 
 async def setup(bot: commands.Bot):

--- a/src/live_messages.py
+++ b/src/live_messages.py
@@ -1,0 +1,419 @@
+import logging
+from collections.abc import Iterable, Sequence
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+import discord
+from sqlalchemy.orm import selectinload
+from sqlmodel import select
+
+from src.bot_instance import get_bot_instance
+from src.config import DEFAULT_GAMES
+from src.crud import (
+    get_guild_config_async,
+    get_live_message_async,
+    set_live_message_async,
+)
+from src.db import get_async_session
+from src.models import Match, Result
+from src.parsers.factory import get_supported_game_slugs
+
+logger = logging.getLogger(__name__)
+
+LIVE_MESSAGE_SCOPES = ("upcoming", "running", "results")
+UPCOMING_WINDOW_DAYS = 5
+UPCOMING_MATCH_LIMIT = 25
+RUNNING_MATCH_LIMIT = 25
+RESULTS_MATCH_LIMIT = 10
+GAME_DISPLAY_NAMES = {
+    "lol": "LoL",
+    "cs2": "CS2",
+}
+
+
+def normalize_enabled_games(
+    raw_games: Optional[str],
+    *,
+    default_games: Optional[Sequence[str]] = None,
+) -> list[str]:
+    supported = set(get_supported_game_slugs())
+    defaults = list(default_games or DEFAULT_GAMES or ("lol",))
+    if not raw_games:
+        return [game for game in defaults if game in supported] or ["lol"]
+
+    seen = set()
+    normalized = []
+    for raw in raw_games.split(","):
+        game = raw.strip().lower()
+        if not game or game not in supported or game in seen:
+            continue
+        seen.add(game)
+        normalized.append(game)
+    return (
+        normalized
+        or [game for game in defaults if game in supported]
+        or ["lol"]
+    )
+
+
+def format_enabled_games(raw_games: Optional[str]) -> str:
+    return ", ".join(
+        _game_display_name(game) for game in normalize_enabled_games(raw_games)
+    )
+
+
+async def refresh_all_live_messages() -> None:
+    bot = get_bot_instance()
+    if not bot:
+        return
+
+    guilds = getattr(bot, "guilds", None)
+    if not isinstance(guilds, (list, tuple, set)):
+        return
+
+    for guild in guilds:
+        await refresh_live_messages_for_guild(guild)
+
+
+async def refresh_live_messages_for_games(games: Iterable[str]) -> None:
+    bot = get_bot_instance()
+    if not bot:
+        return
+
+    guilds = getattr(bot, "guilds", None)
+    if not isinstance(guilds, (list, tuple, set)):
+        return
+
+    target_games = {
+        game.strip().lower()
+        for game in games
+        if game and game.strip().lower() in get_supported_game_slugs()
+    }
+    if not target_games:
+        return
+
+    for guild in guilds:
+        await refresh_live_messages_for_guild(guild, games=target_games)
+
+
+async def refresh_live_messages_for_guild(
+    guild: discord.Guild, games: Optional[Iterable[str]] = None
+) -> None:
+    async with get_async_session() as session:
+        cfg = await get_guild_config_async(session, getattr(guild, "id", None))
+        enabled_games = set(
+            normalize_enabled_games(getattr(cfg, "enabled_games", None))
+        )
+        target_games = enabled_games
+        if games is not None:
+            requested = {game.strip().lower() for game in games if game}
+            target_games = enabled_games.intersection(requested)
+
+        if not target_games:
+            return
+
+        for game in sorted(target_games):
+            for scope in LIVE_MESSAGE_SCOPES:
+                try:
+                    await _refresh_guild_scope(
+                        session,
+                        guild,
+                        cfg,
+                        game,
+                        scope,
+                    )
+                except Exception:
+                    logger.exception(
+                        "Failed refreshing %s live message for guild %s (%s)",
+                        scope,
+                        getattr(guild, "id", None),
+                        game,
+                    )
+
+
+async def _refresh_guild_scope(
+    session, guild, cfg, game: str, scope: str
+) -> None:
+    live_record = await get_live_message_async(session, guild.id, scope, game)
+    channel = await _resolve_live_channel(guild, cfg, live_record)
+    if channel is None:
+        logger.debug(
+            "Skipping %s live message for guild %s (%s): no writable channel",
+            scope,
+            getattr(guild, "id", None),
+            game,
+        )
+        return
+
+    embed = await _build_live_message_embed(session, game, scope)
+    await _edit_or_create_live_message(
+        session,
+        guild,
+        channel,
+        live_record,
+        embed,
+        scope,
+        game,
+    )
+
+
+def _get_preferred_live_channel_id(cfg, live_record) -> Optional[int]:
+    if cfg and getattr(cfg, "live_updates_channel_id", None):
+        return cfg.live_updates_channel_id
+    if cfg and getattr(cfg, "announcement_channel_id", None):
+        return cfg.announcement_channel_id
+    if live_record and getattr(live_record, "channel_id", None):
+        return live_record.channel_id
+    return None
+
+
+async def _resolve_live_channel(guild, cfg, live_record):
+    channel_id = _get_preferred_live_channel_id(cfg, live_record)
+    if channel_id is None:
+        return None
+
+    try:
+        channel = guild.get_channel(channel_id)
+        if channel is None:
+            channel = await guild.fetch_channel(channel_id)
+    except Exception:
+        logger.exception(
+            "Failed resolving live message channel %s for guild %s",
+            channel_id,
+            getattr(guild, "id", None),
+        )
+        return None
+
+    if not _channel_supports_live_messages(channel, guild):
+        return None
+    return channel
+
+
+def _channel_supports_live_messages(channel, guild) -> bool:
+    try:
+        if not hasattr(channel, "permissions_for"):
+            return True
+        member = getattr(guild, "me", None)
+        if member is None:
+            return True
+        perms = channel.permissions_for(member)
+        return bool(perms.send_messages and perms.embed_links)
+    except Exception:
+        logger.exception(
+            "Failed checking channel permissions for guild %s",
+            getattr(guild, "id", None),
+        )
+        return False
+
+
+async def _edit_or_create_live_message(
+    session,
+    guild,
+    channel,
+    live_record,
+    embed: discord.Embed,
+    scope: str,
+    game: str,
+) -> None:
+    should_try_edit = bool(
+        live_record
+        and getattr(live_record, "message_id", None)
+        and getattr(live_record, "channel_id", None)
+        == getattr(channel, "id", None)
+    )
+    if should_try_edit:
+        try:
+            message = await channel.fetch_message(live_record.message_id)
+            await message.edit(embed=embed)
+            await set_live_message_async(
+                session,
+                guild.id,
+                channel.id,
+                message.id,
+                scope,
+                game,
+            )
+            return
+        except discord.NotFound:
+            logger.info(
+                "Tracked live message %s missing in guild %s; recreating",
+                getattr(live_record, "message_id", None),
+                guild.id,
+            )
+        except Exception:
+            logger.exception(
+                "Failed editing %s live message for guild %s (%s)",
+                scope,
+                guild.id,
+                game,
+            )
+            return
+
+    try:
+        message = await channel.send(embed=embed)
+    except Exception:
+        logger.exception(
+            "Failed creating %s live message for guild %s (%s) in channel %s",
+            scope,
+            guild.id,
+            game,
+            getattr(channel, "id", None),
+        )
+        return
+
+    await set_live_message_async(
+        session,
+        guild.id,
+        channel.id,
+        message.id,
+        scope,
+        game,
+    )
+
+
+async def _build_live_message_embed(
+    session, game: str, scope: str
+) -> discord.Embed:
+    if scope == "upcoming":
+        matches = await _fetch_upcoming_matches(session, game)
+        return _build_upcoming_embed(game, matches)
+    if scope == "running":
+        matches = await _fetch_running_matches(session, game)
+        return _build_running_embed(game, matches)
+    results = await _fetch_recent_results(session, game)
+    return _build_results_embed(game, results)
+
+
+async def _fetch_upcoming_matches(session, game: str) -> list[Match]:
+    now = datetime.now(timezone.utc)
+    cutoff = now + timedelta(days=UPCOMING_WINDOW_DAYS)
+    stmt = (
+        select(Match)
+        .options(selectinload(Match.contest))
+        .where(Match.game == game)
+        .where(Match.status == "not_started")
+        .where(Match.scheduled_time >= now)
+        .where(Match.scheduled_time <= cutoff)
+        .order_by(Match.scheduled_time, Match.id)
+        .limit(UPCOMING_MATCH_LIMIT)
+    )
+    return list((await session.exec(stmt)).all())
+
+
+async def _fetch_running_matches(session, game: str) -> list[Match]:
+    stmt = (
+        select(Match)
+        .options(selectinload(Match.contest))
+        .where(Match.game == game)
+        .where(Match.status == "running")
+        .order_by(Match.scheduled_time, Match.id)
+        .limit(RUNNING_MATCH_LIMIT)
+    )
+    return list((await session.exec(stmt)).all())
+
+
+async def _fetch_recent_results(
+    session, game: str
+) -> list[tuple[Match, Result]]:
+    stmt = (
+        select(Match, Result)
+        .join(Result, Result.match_id == Match.id)
+        .options(selectinload(Match.contest))
+        .where(Match.game == game)
+        .order_by(Match.scheduled_time.desc(), Match.id.desc())
+        .limit(RESULTS_MATCH_LIMIT)
+    )
+    return list((await session.exec(stmt)).all())
+
+
+def _build_upcoming_embed(
+    game: str, matches: Sequence[Match]
+) -> discord.Embed:
+    title = f"{_game_display_name(game)} Upcoming Matches"
+    if not matches:
+        description = "No matches are scheduled in the next 5 days."
+    else:
+        description = "\n\n".join(
+            _format_upcoming_line(match) for match in matches
+        )
+    return _build_live_embed(title, description, discord.Color.blue())
+
+
+def _build_running_embed(game: str, matches: Sequence[Match]) -> discord.Embed:
+    title = f"{_game_display_name(game)} Live Matches"
+    if not matches:
+        description = "No matches are currently live."
+    else:
+        description = "\n\n".join(
+            _format_running_line(match) for match in matches
+        )
+    return _build_live_embed(title, description, discord.Color.orange())
+
+
+def _build_results_embed(
+    game: str, results: Sequence[tuple[Match, Result]]
+) -> discord.Embed:
+    title = f"{_game_display_name(game)} Recent Results"
+    if not results:
+        description = "No recent results to show yet."
+    else:
+        description = "\n\n".join(
+            _format_result_line(match, result) for match, result in results
+        )
+    return _build_live_embed(title, description, discord.Color.gold())
+
+
+def _build_live_embed(
+    title: str, description: str, color: discord.Color
+) -> discord.Embed:
+    return discord.Embed(
+        title=title,
+        description=description,
+        color=color,
+        timestamp=datetime.now(timezone.utc),
+    )
+
+
+def _format_upcoming_line(match: Match) -> str:
+    ts = int(match.scheduled_time.timestamp())
+    contest_name = _contest_name(match)
+    return (
+        f"**{match.team1}** vs **{match.team2}**\n"
+        f"{contest_name} • <t:{ts}:F> • "
+        f"<t:{ts}:R>{_best_of_suffix(match)}"
+    )
+
+
+def _format_running_line(match: Match) -> str:
+    score = match.last_announced_score or "Live now"
+    contest_name = _contest_name(match)
+    return (
+        f"**{match.team1}** vs **{match.team2}**\n"
+        f"{contest_name} • ||{score}||{_best_of_suffix(match)}"
+    )
+
+
+def _format_result_line(match: Match, result: Result) -> str:
+    contest_name = _contest_name(match)
+    winner = result.winner or "Winner TBD"
+    score = result.score or "Final"
+    return (
+        f"**{match.team1}** vs **{match.team2}**\n"
+        f"{contest_name} • Winner: ||{winner}|| • "
+        f"Score: ||{score}||"
+    )
+
+
+def _contest_name(match: Match) -> str:
+    contest = getattr(match, "contest", None)
+    return getattr(contest, "name", "Unknown contest")
+
+
+def _best_of_suffix(match: Match) -> str:
+    if getattr(match, "best_of", None):
+        return f" • Bo{match.best_of}"
+    return ""
+
+
+def _game_display_name(game: str) -> str:
+    return GAME_DISPLAY_NAMES.get(game, game.upper())

--- a/src/live_messages.py
+++ b/src/live_messages.py
@@ -1,5 +1,6 @@
 import logging
 from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
@@ -31,29 +32,32 @@ GAME_DISPLAY_NAMES = {
 }
 
 
+@dataclass(frozen=True)
+class LiveMessageScope:
+    guild: discord.Guild
+    game: str
+    scope: str
+
+
+@dataclass(frozen=True)
+class LiveMessageTarget:
+    channel: object
+    live_record: Optional[object]
+    scope: LiveMessageScope
+
+
 def normalize_enabled_games(
     raw_games: Optional[str],
     *,
     default_games: Optional[Sequence[str]] = None,
 ) -> list[str]:
     supported = set(get_supported_game_slugs())
-    defaults = list(default_games or DEFAULT_GAMES or ("lol",))
+    defaults = _get_default_supported_games(default_games, supported)
     if not raw_games:
-        return [game for game in defaults if game in supported] or ["lol"]
+        return defaults
 
-    seen = set()
-    normalized = []
-    for raw in raw_games.split(","):
-        game = raw.strip().lower()
-        if not game or game not in supported or game in seen:
-            continue
-        seen.add(game)
-        normalized.append(game)
-    return (
-        normalized
-        or [game for game in defaults if game in supported]
-        or ["lol"]
-    )
+    normalized = _parse_supported_games(raw_games, supported)
+    return normalized or defaults
 
 
 def format_enabled_games(raw_games: Optional[str]) -> str:
@@ -68,7 +72,7 @@ async def refresh_all_live_messages() -> None:
         return
 
     guilds = getattr(bot, "guilds", None)
-    if not isinstance(guilds, (list, tuple, set)):
+    if guilds is None:
         return
 
     for guild in guilds:
@@ -81,7 +85,7 @@ async def refresh_live_messages_for_games(games: Iterable[str]) -> None:
         return
 
     guilds = getattr(bot, "guilds", None)
-    if not isinstance(guilds, (list, tuple, set)):
+    if guilds is None:
         return
 
     target_games = {
@@ -99,62 +103,120 @@ async def refresh_live_messages_for_games(games: Iterable[str]) -> None:
 async def refresh_live_messages_for_guild(
     guild: discord.Guild, games: Optional[Iterable[str]] = None
 ) -> None:
-    async with get_async_session() as session:
-        cfg = await get_guild_config_async(session, getattr(guild, "id", None))
-        enabled_games = set(
-            normalize_enabled_games(getattr(cfg, "enabled_games", None))
-        )
-        target_games = enabled_games
-        if games is not None:
-            requested = {game.strip().lower() for game in games if game}
-            target_games = enabled_games.intersection(requested)
+    cfg = await _load_guild_config(guild)
+    enabled_games = set(
+        normalize_enabled_games(getattr(cfg, "enabled_games", None))
+    )
+    target_games = enabled_games
+    if games is not None:
+        requested = {game.strip().lower() for game in games if game}
+        target_games = enabled_games.intersection(requested)
 
-        if not target_games:
-            return
+    if not target_games:
+        return
 
-        for game in sorted(target_games):
-            for scope in LIVE_MESSAGE_SCOPES:
-                try:
-                    await _refresh_guild_scope(
-                        session,
-                        guild,
-                        cfg,
-                        game,
-                        scope,
-                    )
-                except Exception:
-                    logger.exception(
-                        "Failed refreshing %s live message for guild %s (%s)",
-                        scope,
-                        getattr(guild, "id", None),
-                        game,
-                    )
+    for game in sorted(target_games):
+        for scope in LIVE_MESSAGE_SCOPES:
+            try:
+                await _refresh_guild_scope(
+                    cfg,
+                    LiveMessageScope(guild=guild, game=game, scope=scope),
+                )
+            except Exception:
+                logger.exception(
+                    "Failed refreshing %s live message for guild %s (%s)",
+                    scope,
+                    getattr(guild, "id", None),
+                    game,
+                )
 
 
 async def _refresh_guild_scope(
-    session, guild, cfg, game: str, scope: str
+    cfg,
+    live_scope: LiveMessageScope,
 ) -> None:
-    live_record = await get_live_message_async(session, guild.id, scope, game)
-    channel = await _resolve_live_channel(guild, cfg, live_record)
+    live_record = await _load_live_record(live_scope)
+    channel = await _resolve_live_channel(
+        live_scope.guild,
+        cfg,
+        live_record,
+    )
     if channel is None:
         logger.debug(
             "Skipping %s live message for guild %s (%s): no writable channel",
-            scope,
-            getattr(guild, "id", None),
-            game,
+            live_scope.scope,
+            getattr(live_scope.guild, "id", None),
+            live_scope.game,
         )
         return
 
-    embed = await _build_live_message_embed(session, game, scope)
+    embed = await _build_live_message_embed(live_scope)
     await _edit_or_create_live_message(
-        session,
-        guild,
-        channel,
-        live_record,
+        LiveMessageTarget(
+            channel=channel,
+            live_record=live_record,
+            scope=live_scope,
+        ),
         embed,
-        scope,
-        game,
     )
+
+
+async def _load_guild_config(guild: discord.Guild):
+    async with get_async_session() as session:
+        return await get_guild_config_async(
+            session,
+            getattr(guild, "id", None),
+        )
+
+
+async def _load_live_record(live_scope: LiveMessageScope):
+    async with get_async_session() as session:
+        return await get_live_message_async(
+            session,
+            live_scope.guild.id,
+            live_scope.scope,
+            live_scope.game,
+        )
+
+
+async def _persist_live_message_pointer(
+    live_scope: LiveMessageScope, channel_id: int, message_id: int
+) -> None:
+    async with get_async_session() as session:
+        await set_live_message_async(
+            session,
+            live_scope.guild.id,
+            channel_id,
+            message_id,
+            live_scope.scope,
+            live_scope.game,
+        )
+
+
+def _get_default_supported_games(
+    default_games: Optional[Sequence[str]],
+    supported: set[str],
+) -> list[str]:
+    defaults = list(default_games or DEFAULT_GAMES or ("lol",))
+    filtered = [game for game in defaults if game in supported]
+    return filtered or ["lol"]
+
+
+def _parse_supported_games(
+    raw_games: str,
+    supported: set[str],
+) -> list[str]:
+    seen = set()
+    normalized = []
+    for raw in raw_games.split(","):
+        game = raw.strip().lower()
+        if not game or game in seen:
+            continue
+        if game not in supported:
+            continue
+        seen.add(game)
+        normalized.append(game)
+    return normalized
 
 
 def _get_preferred_live_channel_id(cfg, live_record) -> Optional[int]:
@@ -207,160 +269,172 @@ def _channel_supports_live_messages(channel, guild) -> bool:
 
 
 async def _edit_or_create_live_message(
-    session,
-    guild,
-    channel,
-    live_record,
+    target: LiveMessageTarget,
     embed: discord.Embed,
-    scope: str,
-    game: str,
 ) -> None:
-    should_try_edit = bool(
-        live_record
-        and getattr(live_record, "message_id", None)
-        and getattr(live_record, "channel_id", None)
-        == getattr(channel, "id", None)
-    )
-    if should_try_edit:
+    if _can_edit_tracked_message(target):
         try:
-            message = await channel.fetch_message(live_record.message_id)
+            message = await target.channel.fetch_message(
+                target.live_record.message_id
+            )
             await message.edit(embed=embed)
-            await set_live_message_async(
-                session,
-                guild.id,
-                channel.id,
+            await _persist_live_message_pointer(
+                target.scope,
+                target.channel.id,
                 message.id,
-                scope,
-                game,
             )
             return
         except discord.NotFound:
             logger.info(
                 "Tracked live message %s missing in guild %s; recreating",
-                getattr(live_record, "message_id", None),
-                guild.id,
+                getattr(target.live_record, "message_id", None),
+                target.scope.guild.id,
             )
         except Exception:
             logger.exception(
                 "Failed editing %s live message for guild %s (%s)",
-                scope,
-                guild.id,
-                game,
+                target.scope.scope,
+                target.scope.guild.id,
+                target.scope.game,
             )
             return
 
     try:
-        message = await channel.send(embed=embed)
+        message = await target.channel.send(embed=embed)
     except Exception:
         logger.exception(
             "Failed creating %s live message for guild %s (%s) in channel %s",
-            scope,
-            guild.id,
-            game,
-            getattr(channel, "id", None),
+            target.scope.scope,
+            target.scope.guild.id,
+            target.scope.game,
+            getattr(target.channel, "id", None),
         )
         return
 
-    await set_live_message_async(
-        session,
-        guild.id,
-        channel.id,
+    await _persist_live_message_pointer(
+        target.scope,
+        target.channel.id,
         message.id,
-        scope,
-        game,
+    )
+
+
+def _can_edit_tracked_message(target: LiveMessageTarget) -> bool:
+    return bool(
+        target.live_record
+        and getattr(target.live_record, "message_id", None)
+        and getattr(target.live_record, "channel_id", None)
+        == getattr(target.channel, "id", None)
     )
 
 
 async def _build_live_message_embed(
-    session, game: str, scope: str
+    live_scope: LiveMessageScope,
 ) -> discord.Embed:
-    if scope == "upcoming":
-        matches = await _fetch_upcoming_matches(session, game)
-        return _build_upcoming_embed(game, matches)
-    if scope == "running":
-        matches = await _fetch_running_matches(session, game)
-        return _build_running_embed(game, matches)
-    results = await _fetch_recent_results(session, game)
-    return _build_results_embed(game, results)
+    if live_scope.scope == "upcoming":
+        matches = await _fetch_upcoming_matches(live_scope.game)
+        return _build_upcoming_embed(live_scope.game, matches)
+    if live_scope.scope == "running":
+        matches = await _fetch_running_matches(live_scope.game)
+        return _build_running_embed(live_scope.game, matches)
+    results = await _fetch_recent_results(live_scope.game)
+    return _build_results_embed(live_scope.game, results)
 
 
-async def _fetch_upcoming_matches(session, game: str) -> list[Match]:
+async def _fetch_upcoming_matches(game: str) -> list[Match]:
     now = datetime.now(timezone.utc)
     cutoff = now + timedelta(days=UPCOMING_WINDOW_DAYS)
-    stmt = (
-        select(Match)
-        .options(selectinload(Match.contest))
-        .where(Match.game == game)
-        .where(Match.status == "not_started")
-        .where(Match.scheduled_time >= now)
-        .where(Match.scheduled_time <= cutoff)
-        .order_by(Match.scheduled_time, Match.id)
-        .limit(UPCOMING_MATCH_LIMIT)
-    )
-    return list((await session.exec(stmt)).all())
+    async with get_async_session() as session:
+        stmt = (
+            select(Match)
+            .options(selectinload(Match.contest))
+            .where(Match.game == game)
+            .where(Match.status == "not_started")
+            .where(Match.scheduled_time >= now)
+            .where(Match.scheduled_time <= cutoff)
+            .order_by(Match.scheduled_time, Match.id)
+            .limit(UPCOMING_MATCH_LIMIT)
+        )
+        return list((await session.exec(stmt)).all())
 
 
-async def _fetch_running_matches(session, game: str) -> list[Match]:
-    stmt = (
-        select(Match)
-        .options(selectinload(Match.contest))
-        .where(Match.game == game)
-        .where(Match.status == "running")
-        .order_by(Match.scheduled_time, Match.id)
-        .limit(RUNNING_MATCH_LIMIT)
-    )
-    return list((await session.exec(stmt)).all())
+async def _fetch_running_matches(game: str) -> list[Match]:
+    async with get_async_session() as session:
+        stmt = (
+            select(Match)
+            .options(selectinload(Match.contest))
+            .where(Match.game == game)
+            .where(Match.status == "running")
+            .order_by(Match.scheduled_time, Match.id)
+            .limit(RUNNING_MATCH_LIMIT)
+        )
+        return list((await session.exec(stmt)).all())
 
 
-async def _fetch_recent_results(
-    session, game: str
-) -> list[tuple[Match, Result]]:
-    stmt = (
-        select(Match, Result)
-        .join(Result, Result.match_id == Match.id)
-        .options(selectinload(Match.contest))
-        .where(Match.game == game)
-        .order_by(Match.scheduled_time.desc(), Match.id.desc())
-        .limit(RESULTS_MATCH_LIMIT)
-    )
-    return list((await session.exec(stmt)).all())
+async def _fetch_recent_results(game: str) -> list[tuple[Match, Result]]:
+    async with get_async_session() as session:
+        stmt = (
+            select(Match, Result)
+            .join(Result, Result.match_id == Match.id)
+            .options(selectinload(Match.contest))
+            .where(Match.game == game)
+            .order_by(Match.scheduled_time.desc(), Match.id.desc())
+            .limit(RESULTS_MATCH_LIMIT)
+        )
+        return list((await session.exec(stmt)).all())
 
 
 def _build_upcoming_embed(
     game: str, matches: Sequence[Match]
 ) -> discord.Embed:
-    title = f"{_game_display_name(game)} Upcoming Matches"
-    if not matches:
-        description = "No matches are scheduled in the next 5 days."
-    else:
-        description = "\n\n".join(
-            _format_upcoming_line(match) for match in matches
-        )
-    return _build_live_embed(title, description, discord.Color.blue())
+    return _build_scoped_embed(
+        game,
+        matches,
+        title_suffix="Upcoming Matches",
+        empty_description="No matches are scheduled in the next 5 days.",
+        formatter=_format_upcoming_line,
+        color=discord.Color.blue(),
+    )
 
 
 def _build_running_embed(game: str, matches: Sequence[Match]) -> discord.Embed:
-    title = f"{_game_display_name(game)} Live Matches"
-    if not matches:
-        description = "No matches are currently live."
-    else:
-        description = "\n\n".join(
-            _format_running_line(match) for match in matches
-        )
-    return _build_live_embed(title, description, discord.Color.orange())
+    return _build_scoped_embed(
+        game,
+        matches,
+        title_suffix="Live Matches",
+        empty_description="No matches are currently live.",
+        formatter=_format_running_line,
+        color=discord.Color.orange(),
+    )
 
 
 def _build_results_embed(
     game: str, results: Sequence[tuple[Match, Result]]
 ) -> discord.Embed:
-    title = f"{_game_display_name(game)} Recent Results"
-    if not results:
-        description = "No recent results to show yet."
+    return _build_scoped_embed(
+        game,
+        results,
+        title_suffix="Recent Results",
+        empty_description="No recent results to show yet.",
+        formatter=_format_result_entry,
+        color=discord.Color.gold(),
+    )
+
+
+def _build_scoped_embed(
+    game: str,
+    entries: Sequence,
+    *,
+    title_suffix: str,
+    empty_description: str,
+    formatter,
+    color: discord.Color,
+) -> discord.Embed:
+    title = f"{_game_display_name(game)} {title_suffix}"
+    if not entries:
+        description = empty_description
     else:
-        description = "\n\n".join(
-            _format_result_line(match, result) for match, result in results
-        )
-    return _build_live_embed(title, description, discord.Color.gold())
+        description = "\n\n".join(formatter(entry) for entry in entries)
+    return _build_live_embed(title, description, color)
 
 
 def _build_live_embed(
@@ -402,6 +476,11 @@ def _format_result_line(match: Match, result: Result) -> str:
         f"{contest_name} • Winner: ||{winner}|| • "
         f"Score: ||{score}||"
     )
+
+
+def _format_result_entry(entry: tuple[Match, Result]) -> str:
+    match, result = entry
+    return _format_result_line(match, result)
 
 
 def _contest_name(match: Match) -> str:

--- a/src/live_messages.py
+++ b/src/live_messages.py
@@ -370,8 +370,10 @@ async def _fetch_running_matches(game: str) -> list[Match]:
         stmt = (
             select(Match)
             .options(selectinload(Match.contest))
+            .outerjoin(Result, Result.match_id == Match.id)
             .where(Match.game == game)
             .where(Match.status == "running")
+            .where(Result.id.is_(None))
             .order_by(Match.scheduled_time, Match.id)
             .limit(RUNNING_MATCH_LIMIT)
         )

--- a/src/live_messages.py
+++ b/src/live_messages.py
@@ -46,6 +46,14 @@ class LiveMessageTarget:
     scope: LiveMessageScope
 
 
+@dataclass(frozen=True)
+class LiveEmbedSpec:
+    title_suffix: str
+    empty_description: str
+    formatter: object
+    color: discord.Color
+
+
 def normalize_enabled_games(
     raw_games: Optional[str],
     *,
@@ -389,10 +397,12 @@ def _build_upcoming_embed(
     return _build_scoped_embed(
         game,
         matches,
-        title_suffix="Upcoming Matches",
-        empty_description="No matches are scheduled in the next 5 days.",
-        formatter=_format_upcoming_line,
-        color=discord.Color.blue(),
+        LiveEmbedSpec(
+            title_suffix="Upcoming Matches",
+            empty_description="No matches are scheduled in the next 5 days.",
+            formatter=_format_upcoming_line,
+            color=discord.Color.blue(),
+        ),
     )
 
 
@@ -400,10 +410,12 @@ def _build_running_embed(game: str, matches: Sequence[Match]) -> discord.Embed:
     return _build_scoped_embed(
         game,
         matches,
-        title_suffix="Live Matches",
-        empty_description="No matches are currently live.",
-        formatter=_format_running_line,
-        color=discord.Color.orange(),
+        LiveEmbedSpec(
+            title_suffix="Live Matches",
+            empty_description="No matches are currently live.",
+            formatter=_format_running_line,
+            color=discord.Color.orange(),
+        ),
     )
 
 
@@ -413,28 +425,26 @@ def _build_results_embed(
     return _build_scoped_embed(
         game,
         results,
-        title_suffix="Recent Results",
-        empty_description="No recent results to show yet.",
-        formatter=_format_result_entry,
-        color=discord.Color.gold(),
+        LiveEmbedSpec(
+            title_suffix="Recent Results",
+            empty_description="No recent results to show yet.",
+            formatter=_format_result_entry,
+            color=discord.Color.gold(),
+        ),
     )
 
 
 def _build_scoped_embed(
     game: str,
     entries: Sequence,
-    *,
-    title_suffix: str,
-    empty_description: str,
-    formatter,
-    color: discord.Color,
+    spec: LiveEmbedSpec,
 ) -> discord.Embed:
-    title = f"{_game_display_name(game)} {title_suffix}"
+    title = f"{_game_display_name(game)} {spec.title_suffix}"
     if not entries:
-        description = empty_description
+        description = spec.empty_description
     else:
-        description = "\n\n".join(formatter(entry) for entry in entries)
-    return _build_live_embed(title, description, color)
+        description = "\n\n".join(spec.formatter(entry) for entry in entries)
+    return _build_live_embed(title, description, spec.color)
 
 
 def _build_live_embed(

--- a/src/notification_batcher.py
+++ b/src/notification_batcher.py
@@ -18,6 +18,7 @@ from src.live_messages import (
 from src.models import Match, Pick, Result, Team
 
 logger = logging.getLogger(__name__)
+_upcoming_live_update_lock = asyncio.Lock()
 
 
 class BatchProcessorSpec:
@@ -556,4 +557,11 @@ batcher = NotificationBatcher()
 
 async def update_upcoming_live_messages() -> None:
     """Refresh all canonical live messages from database state."""
-    await refresh_all_live_messages()
+    if _upcoming_live_update_lock.locked():
+        logger.info(
+            "Skipping live message refresh; another refresh is running."
+        )
+        return
+
+    async with _upcoming_live_update_lock:
+        await refresh_all_live_messages()

--- a/src/notification_batcher.py
+++ b/src/notification_batcher.py
@@ -11,8 +11,11 @@ from sqlmodel import func, or_, select
 
 from src.bot_instance import get_bot_instance
 from src.db import get_async_session
+from src.live_messages import (
+    refresh_all_live_messages,
+    refresh_live_messages_for_games,
+)
 from src.models import Match, Pick, Result, Team
-from src.notification_delivery import DeliveryRequest, deliver_embed
 
 logger = logging.getLogger(__name__)
 
@@ -177,8 +180,7 @@ async def _process_generic(
         build_embed: Function accepting list of data and returning an Embed.
         context_fmt: Format string for log context.
     """
-    bot = get_bot_instance()
-    if not bot:
+    if not get_bot_instance():
         return
 
     async with get_async_session() as session:
@@ -186,26 +188,18 @@ async def _process_generic(
         if not data_list:
             return
 
-        embed = spec.build_embed(data_list)
-        context = f"{spec.context_fmt} for {len(data_list)} matches"
+        games = _extract_games_from_batch(data_list)
 
-        # Derive game slug from the first match when available. Default to
-        # 'lol' for backwards compatibility.
-        try:
-            first_match = data_list[0][0]
-            game_slug = getattr(first_match, "game", "lol")
-        except Exception:
-            game_slug = "lol"
+    await refresh_live_messages_for_games(games)
 
-        await deliver_embed(
-            bot,
-            DeliveryRequest(
-                embed=embed,
-                context=context,
-                game_slug=game_slug,
-                scope_type=spec.scope_type,
-            ),
-        )
+
+def _extract_games_from_batch(data_list: List[Any]) -> set[str]:
+    games = set()
+    for item in data_list:
+        match = item[0] if item else None
+        game = getattr(match, "game", None) or "lol"
+        games.add(game)
+    return games
 
 
 async def _process_reminders(minutes: int, match_ids: List[int]):
@@ -561,68 +555,5 @@ batcher = NotificationBatcher()
 
 
 async def update_upcoming_live_messages() -> None:
-    """
-    Rebuild and deliver the "upcoming" live message for each configured
-    default game. This job is idempotent and uses the database as the
-    source-of-truth for upcoming matches.
-    """
-    bot = get_bot_instance()
-    if not bot:
-        return
-
-    from src.config import DEFAULT_GAMES
-
-    games = DEFAULT_GAMES or ["lol"]
-
-    async with get_async_session() as session:
-        for game in games:
-            # Fetch upcoming matches for this game (next 25)
-            now = datetime.now(timezone.utc)
-            stmt = (
-                select(Match)
-                .options(selectinload(Match.contest))
-                .where(Match.game == game)
-                .where(Match.status == "not_started")
-                .where(Match.scheduled_time >= now)
-                .order_by(Match.scheduled_time)
-                .limit(25)
-            )
-            matches = (await session.exec(stmt)).all()
-            if not matches:
-                continue
-
-            # Build data tuples expected by _populate_list_embed:
-            # (match, team1, team2)
-            teams_map = await _bulk_fetch_teams(session, matches)
-            data = []
-            for m in matches:
-                t1, t2 = _resolve_teams(m, teams_map)
-                data.append((m, t1, t2))
-
-            # Build a simple upcoming embed using the same formatting as
-            # reminders
-            embed = discord.Embed(
-                title="⚔️ Upcoming Matches",
-                description="Matches coming up soon:",
-                color=discord.Color.blue(),
-                timestamp=datetime.now(timezone.utc),
-            )
-            embed = _populate_list_embed(
-                embed,
-                data,
-                lambda d: (
-                    f"**{d[0].team1}** vs **{d[0].team2}** "
-                    f"<t:{int(d[0].scheduled_time.timestamp())}:R>"
-                ),
-            )
-
-            context = f"upcoming live message for {len(matches)} matches"
-            await deliver_embed(
-                bot,
-                DeliveryRequest(
-                    embed=embed,
-                    context=context,
-                    game_slug=game,
-                    scope_type="upcoming",
-                ),
-            )
+    """Refresh all canonical live messages from database state."""
+    await refresh_all_live_messages()

--- a/src/pandascore_polling.py
+++ b/src/pandascore_polling.py
@@ -159,7 +159,11 @@ async def _remove_stale_running_mapping(match_id: int) -> None:
 
 
 async def _fetch_match_data(match):
-    return await _fetch_match_from_pandascore(match.pandascore_id)
+    game_slug = getattr(match, "game", None) or "lol"
+    return await _fetch_match_from_pandascore(
+        match.pandascore_id,
+        game=game_slug,
+    )
 
 
 async def _fetch_running_matches_for_games(games):

--- a/src/pandascore_polling_core.py
+++ b/src/pandascore_polling_core.py
@@ -116,9 +116,13 @@ def _remove_job_if_exists(job_id: str) -> None:
         logger.exception("Failed to remove job %s via scheduler", job_id)
 
 
-async def _fetch_match_from_pandascore(pandascore_id: int) -> Optional[dict]:
+async def _fetch_match_from_pandascore(
+    pandascore_id: int, game: str = "lol"
+) -> Optional[dict]:
     try:
-        return await pandascore_client.fetch_match_by_id(pandascore_id)
+        return await pandascore_client.fetch_match_by_id(
+            pandascore_id, game=game
+        )
     except Exception:
         logger.exception(
             "Failed to fetch match %s from PandaScore", pandascore_id
@@ -190,6 +194,7 @@ async def _handle_winner(
 
     committed = False
     result = None
+    match.status = "finished"
     try:
         result, committed = await _persist_result(
             match, winner, current_score_str
@@ -512,13 +517,23 @@ async def _process_running_match(session, match_data: dict) -> bool:
 
 async def _handle_finished_pandascore_id(pandascore_id: int) -> None:
     try:
-        match_data = await pandascore_client.fetch_match_by_id(pandascore_id)
+        from src.db import get_async_session
+
+        async with get_async_session() as session:
+            match = await crud.get_match_by_pandascore_id(
+                session, pandascore_id
+            )
+            if not match:
+                return
+            game_slug = getattr(match, "game", None) or "lol"
+
+        match_data = await pandascore_client.fetch_match_by_id(
+            pandascore_id, game=game_slug
+        )
         if not match_data or match_data.get("status") != "finished":
             return
 
         try:
-            from src.db import get_async_session
-
             async with get_async_session() as session:
                 match = await crud.get_match_by_pandascore_id(
                     session, pandascore_id

--- a/src/pandascore_sync.py
+++ b/src/pandascore_sync.py
@@ -10,7 +10,7 @@ import logging
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 
 from sqlmodel import select
-from src.models import Result
+from src.models import Match, Result
 from src.pandascore_client import (
     pandascore_client,
     DEFAULT_PAGE_SIZE,
@@ -34,9 +34,22 @@ from src.pandascore_processing import (
     _process_single_match,
     _detect_match_result,
 )
-from src.parsers.factory import get_parser
+from src.parsers.factory import get_parser, get_supported_game_slugs
 
 logger = logging.getLogger(__name__)
+
+
+def _configured_sync_games(requested_game: Optional[str] = None) -> list[str]:
+    if requested_game:
+        return [requested_game]
+
+    from src.config import DEFAULT_GAMES
+
+    supported = set(get_supported_game_slugs())
+    configured = [
+        game for game in (DEFAULT_GAMES or ["lol"]) if game in supported
+    ]
+    return configured or ["lol"]
 
 
 async def _run_post_sync_actions(
@@ -98,20 +111,13 @@ async def _run_post_sync_actions(
 
 
 async def _fetch_matches_for_sync(
-    league_ids: Optional[List[int]], game_slug: Optional[str] = None
+    league_ids: Optional[List[int]], game_slug: str
 ):
     """Fetch upcoming, running and recent past matches for sync.
 
     Returns combined list or None on failure.
     """
     try:
-        # Allow caller or environment defaults to specify which game to fetch.
-        # For now we default to "lol" for backward compatibility.
-        from src.config import DEFAULT_GAMES
-
-        if not game_slug:
-            game_slug = DEFAULT_GAMES[0] if DEFAULT_GAMES else "lol"
-
         upcoming_coro = pandascore_client.fetch_matches(
             "upcoming",
             {
@@ -145,6 +151,26 @@ async def _fetch_matches_for_sync(
     except Exception:
         logger.exception("Failed to fetch matches from PandaScore")
         return None
+
+
+async def _reconcile_finished_matches_for_game(game_slug: str) -> None:
+    async with get_async_session() as db_session:
+        stmt = (
+            select(Match)
+            .where(Match.game == game_slug)
+            .where(Match.status == "running")
+        )
+        running_matches = list((await db_session.exec(stmt)).all())
+
+    for match in running_matches:
+        pandascore_id = getattr(match, "pandascore_id", None)
+        if not pandascore_id:
+            continue
+
+        match_data = await _fetch_pandascore_match(pandascore_id, game_slug)
+        if not match_data:
+            continue
+        await fetch_and_update_match_result(pandascore_id, game_slug=game_slug)
 
 
 async def _process_matches_and_commit(
@@ -208,37 +234,48 @@ async def perform_pandascore_sync(
     """
     logger.info("Starting PandaScore sync...")
 
-    matches_data = await _fetch_matches_for_sync(league_ids, game_slug=game)
-    if matches_data is None:
-        return None
-    if not matches_data:
-        logger.info("No matches found from PandaScore")
-        return {"contests": 0, "matches": 0, "teams": 0}
+    total_summary = {"contests": 0, "matches": 0, "teams": 0}
+    matches_to_schedule: List[Any] = []
+    notifications: List[Tuple[int, int]] = []
+    time_changes: List[Tuple[Any, Any, Any]] = []
 
-    logger.info(
-        "Fetched total of %d matches from PandaScore", len(matches_data)
-    )
-    if game:
-        game_slug = game
-    else:
-        from src.config import DEFAULT_GAMES
+    for game_slug in _configured_sync_games(game):
+        matches_data = await _fetch_matches_for_sync(league_ids, game_slug)
+        if matches_data is None:
+            return None
+        if not matches_data:
+            logger.info("No %s matches found from PandaScore", game_slug)
+            await _reconcile_finished_matches_for_game(game_slug)
+            continue
 
-        game_slug = DEFAULT_GAMES[0] if DEFAULT_GAMES else "lol"
-
-    async with get_async_session() as db_session:
-        (
-            all_matches_to_schedule,
-            all_notifications,
-            all_time_changes,
-            summary,
-        ) = await _process_matches_and_commit(
-            matches_data, db_session, game_slug
+        logger.info(
+            "Fetched total of %d %s matches from PandaScore",
+            len(matches_data),
+            game_slug,
         )
+        async with get_async_session() as db_session:
+            (
+                game_matches_to_schedule,
+                game_notifications,
+                game_time_changes,
+                game_summary,
+            ) = await _process_matches_and_commit(
+                matches_data, db_session, game_slug
+            )
+
+        matches_to_schedule.extend(game_matches_to_schedule)
+        notifications.extend(game_notifications)
+        time_changes.extend(game_time_changes)
+        for key in total_summary:
+            total_summary[key] += game_summary[key]
+        await _reconcile_finished_matches_for_game(game_slug)
 
     await _run_post_sync_actions(
-        all_matches_to_schedule, all_notifications, all_time_changes
+        matches_to_schedule,
+        notifications,
+        time_changes,
     )
-    return summary
+    return total_summary
 
 
 async def sync_running_matches() -> Dict[str, Any]:
@@ -253,40 +290,37 @@ async def sync_running_matches() -> Dict[str, Any]:
     """
     logger.info("Syncing running matches from PandaScore...")
 
-    try:
-        # Default to configured default game if none provided by caller.
-        from src.config import DEFAULT_GAMES
-
-        game_slug = DEFAULT_GAMES[0] if DEFAULT_GAMES else "lol"
-        running_matches = await pandascore_client.fetch_running_matches(
-            game=game_slug
-        )
-    except Exception:
-        logger.exception("Failed to fetch running matches")
-        return {"started": [], "finished": [], "error": True}
-
     started = []
     finished = []
-
-    async with get_async_session() as db_session:
-        for match_data in running_matches:
-            started_id = await maybe_start_running_match(
-                db_session, match_data
+    for game_slug in _configured_sync_games():
+        try:
+            running_matches = await pandascore_client.fetch_running_matches(
+                game=game_slug
             )
-            if started_id:
-                started.append(started_id)
-
-            # Detect finished matches in the same session and collect ids
-            finished_id = await maybe_finish_running_match(
-                db_session, match_data
+        except Exception:
+            logger.exception(
+                "Failed to fetch running matches for %s", game_slug
             )
-            if finished_id:
-                finished.append(finished_id)
+            return {"started": [], "finished": [], "error": True}
 
-            # Yield to the event loop to avoid blocking long syncs
-            await asyncio.sleep(0)
+        async with get_async_session() as db_session:
+            for match_data in running_matches:
+                started_id = await maybe_start_running_match(
+                    db_session, match_data
+                )
+                if started_id:
+                    started.append(started_id)
 
-        await db_session.commit()
+                finished_id = await maybe_finish_running_match(
+                    db_session, match_data
+                )
+                if finished_id:
+                    finished.append(finished_id)
+                await asyncio.sleep(0)
+
+            await db_session.commit()
+
+        await _reconcile_finished_matches_for_game(game_slug)
 
     logger.info(
         "Running matches sync complete: %d started, %d finished",
@@ -304,12 +338,12 @@ def _resolve_match_game(match, match_data: Dict[str, Any]) -> str:
     if videogame.get("slug"):
         return videogame["slug"]
 
-    from src.config import DEFAULT_GAMES
-
-    return DEFAULT_GAMES[0] if DEFAULT_GAMES else "lol"
+    return _configured_sync_games()[0]
 
 
-async def fetch_and_update_match_result(pandascore_id: int) -> bool:
+async def fetch_and_update_match_result(
+    pandascore_id: int, game_slug: Optional[str] = None
+) -> bool:
     """
     Fetch result for a specific match and update the database.
 
@@ -321,24 +355,29 @@ async def fetch_and_update_match_result(pandascore_id: int) -> bool:
     """
     logger.info("Fetching result for PandaScore match %s", pandascore_id)
 
-    match_data = await _fetch_pandascore_match(pandascore_id)
-    if not match_data:
-        return False
-
     async with get_async_session() as db_session:
         match = await _load_db_match(db_session, pandascore_id)
         if not match:
+            return False
+
+        resolved_game = game_slug or _resolve_match_game(match, {})
+        match_data = await _fetch_pandascore_match(
+            pandascore_id, resolved_game
+        )
+        if not match_data:
             return False
 
         if await _result_exists(db_session, match.id):
             logger.info("Match %s already has a result", match.id)
             return True
 
-        game_slug = _resolve_match_game(match, match_data)
-        parser = get_parser(game_slug)
+        resolved_game = _resolve_match_game(match, match_data)
+        parser = get_parser(resolved_game)
         if parser is None:
-            logger.error("No parser available for '%s'", game_slug)
+            logger.error("No parser available for '%s'", resolved_game)
             return False
+        match.status = "finished"
+        db_session.add(match)
         ctx = PandaScoreSyncContext(
             db_session=db_session,
             summary={"contests": 0, "matches": 0, "teams": 0},
@@ -360,10 +399,11 @@ async def fetch_and_update_match_result(pandascore_id: int) -> bool:
 
 async def _fetch_pandascore_match(
     pandascore_id: int,
+    game_slug: str,
 ) -> Optional[Dict[str, Any]]:
     try:
         match_data = await pandascore_client.fetch_match_by_id(
-            pandascore_id, game="lol"
+            pandascore_id, game=game_slug
         )
     except Exception:
         logger.exception("Failed to fetch match %s", pandascore_id)

--- a/src/parsers/factory.py
+++ b/src/parsers/factory.py
@@ -12,6 +12,10 @@ _PARSERS = {
 }
 
 
+def get_supported_game_slugs() -> tuple[str, ...]:
+    return tuple(_PARSERS.keys())
+
+
 def get_parser(game_slug: str) -> Optional[PandaScoreParser]:
     cls = _PARSERS.get(game_slug)
     if cls is None:

--- a/tests/commands/test_config.py
+++ b/tests/commands/test_config.py
@@ -1,8 +1,8 @@
+from dataclasses import dataclass
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
 import pytest
-from dataclasses import dataclass
 
 import src.commands.config as config_commands
 
@@ -132,9 +132,9 @@ async def test_set_games_rejects_unsupported_slug(mocked_interaction):
 
 
 @pytest.mark.asyncio
-async def test_add_game_updates_enabled_games(mocked_interaction):
-    await _assert_game_command_result(
-        mocked_interaction,
+@pytest.mark.parametrize(
+    "case",
+    [
         _GameCommandCase(
             guild_id=101,
             command_name="add_game",
@@ -144,13 +144,6 @@ async def test_add_game_updates_enabled_games(mocked_interaction):
             expected_games=["lol", "cs2"],
             expected_message="Enabled games: LoL, CS2",
         ),
-    )
-
-
-@pytest.mark.asyncio
-async def test_add_game_handles_unset_enabled_games(mocked_interaction):
-    await _assert_game_command_result(
-        mocked_interaction,
         _GameCommandCase(
             guild_id=111,
             command_name="add_game",
@@ -160,13 +153,6 @@ async def test_add_game_handles_unset_enabled_games(mocked_interaction):
             expected_games=["cs2"],
             expected_message="Enabled games: CS2",
         ),
-    )
-
-
-@pytest.mark.asyncio
-async def test_remove_game_removes_enabled_slug(mocked_interaction):
-    await _assert_game_command_result(
-        mocked_interaction,
         _GameCommandCase(
             guild_id=202,
             command_name="remove_game",
@@ -176,13 +162,6 @@ async def test_remove_game_removes_enabled_slug(mocked_interaction):
             expected_games=["lol"],
             expected_message="Enabled games: LoL",
         ),
-    )
-
-
-@pytest.mark.asyncio
-async def test_remove_game_filters_stale_games(mocked_interaction):
-    await _assert_game_command_result(
-        mocked_interaction,
         _GameCommandCase(
             guild_id=303,
             command_name="remove_game",
@@ -192,4 +171,10 @@ async def test_remove_game_filters_stale_games(mocked_interaction):
             expected_games=["lol"],
             expected_message="Enabled games: LoL",
         ),
-    )
+    ],
+)
+async def test_game_command_updates_enabled_games(
+    mocked_interaction,
+    case: _GameCommandCase,
+):
+    await _assert_game_command_result(mocked_interaction, case)

--- a/tests/commands/test_config.py
+++ b/tests/commands/test_config.py
@@ -2,23 +2,28 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
 import pytest
+from dataclasses import dataclass
 
 import src.commands.config as config_commands
 
 
+@dataclass(frozen=True)
+class _GameCommandCase:
+    guild_id: int
+    command_name: str
+    game: str
+    loaded_games: object
+    stored_games: str
+    expected_games: list[str]
+    expected_message: str
+
+
 async def _assert_game_command_result(
     mocked_interaction,
-    *,
-    guild_id: int,
-    command_name: str,
-    game: str,
-    loaded_games,
-    stored_games: str,
-    expected_games: list[str],
-    expected_message: str,
+    case: _GameCommandCase,
 ):
-    mocked_interaction.guild.id = guild_id
-    command = getattr(config_commands, command_name)
+    mocked_interaction.guild.id = case.guild_id
+    command = getattr(config_commands, case.command_name)
 
     with patch.object(
         config_commands,
@@ -29,18 +34,18 @@ async def _assert_game_command_result(
         config_commands,
         "_load_enabled_games",
         new_callable=AsyncMock,
-        return_value=loaded_games,
+        return_value=case.loaded_games,
     ), patch.object(
         config_commands,
         "_update_enabled_games",
         new_callable=AsyncMock,
-        return_value=stored_games,
+        return_value=case.stored_games,
     ) as mock_update:
-        await command.callback(mocked_interaction, game)
+        await command.callback(mocked_interaction, case.game)
 
-    mock_update.assert_awaited_once_with(guild_id, expected_games)
+    mock_update.assert_awaited_once_with(case.guild_id, case.expected_games)
     mocked_interaction.followup.send.assert_awaited_once_with(
-        expected_message,
+        case.expected_message,
         ephemeral=True,
     )
 
@@ -130,13 +135,15 @@ async def test_set_games_rejects_unsupported_slug(mocked_interaction):
 async def test_add_game_updates_enabled_games(mocked_interaction):
     await _assert_game_command_result(
         mocked_interaction,
-        guild_id=101,
-        command_name="add_game",
-        game="cs2",
-        loaded_games=["lol"],
-        stored_games="lol,cs2",
-        expected_games=["lol", "cs2"],
-        expected_message="Enabled games: LoL, CS2",
+        _GameCommandCase(
+            guild_id=101,
+            command_name="add_game",
+            game="cs2",
+            loaded_games=["lol"],
+            stored_games="lol,cs2",
+            expected_games=["lol", "cs2"],
+            expected_message="Enabled games: LoL, CS2",
+        ),
     )
 
 
@@ -144,13 +151,15 @@ async def test_add_game_updates_enabled_games(mocked_interaction):
 async def test_add_game_handles_unset_enabled_games(mocked_interaction):
     await _assert_game_command_result(
         mocked_interaction,
-        guild_id=111,
-        command_name="add_game",
-        game="cs2",
-        loaded_games=None,
-        stored_games="cs2",
-        expected_games=["cs2"],
-        expected_message="Enabled games: CS2",
+        _GameCommandCase(
+            guild_id=111,
+            command_name="add_game",
+            game="cs2",
+            loaded_games=None,
+            stored_games="cs2",
+            expected_games=["cs2"],
+            expected_message="Enabled games: CS2",
+        ),
     )
 
 
@@ -158,13 +167,15 @@ async def test_add_game_handles_unset_enabled_games(mocked_interaction):
 async def test_remove_game_removes_enabled_slug(mocked_interaction):
     await _assert_game_command_result(
         mocked_interaction,
-        guild_id=202,
-        command_name="remove_game",
-        game="cs2",
-        loaded_games=["lol", "cs2"],
-        stored_games="lol",
-        expected_games=["lol"],
-        expected_message="Enabled games: LoL",
+        _GameCommandCase(
+            guild_id=202,
+            command_name="remove_game",
+            game="cs2",
+            loaded_games=["lol", "cs2"],
+            stored_games="lol",
+            expected_games=["lol"],
+            expected_message="Enabled games: LoL",
+        ),
     )
 
 
@@ -172,11 +183,13 @@ async def test_remove_game_removes_enabled_slug(mocked_interaction):
 async def test_remove_game_filters_stale_games(mocked_interaction):
     await _assert_game_command_result(
         mocked_interaction,
-        guild_id=303,
-        command_name="remove_game",
-        game="cs2",
-        loaded_games=["lol", "stale", "cs2"],
-        stored_games="lol",
-        expected_games=["lol"],
-        expected_message="Enabled games: LoL",
+        _GameCommandCase(
+            guild_id=303,
+            command_name="remove_game",
+            game="cs2",
+            loaded_games=["lol", "stale", "cs2"],
+            stored_games="lol",
+            expected_games=["lol"],
+            expected_message="Enabled games: LoL",
+        ),
     )

--- a/tests/commands/test_config.py
+++ b/tests/commands/test_config.py
@@ -6,6 +6,45 @@ import pytest
 import src.commands.config as config_commands
 
 
+async def _assert_game_command_result(
+    mocked_interaction,
+    *,
+    guild_id: int,
+    command_name: str,
+    game: str,
+    loaded_games,
+    stored_games: str,
+    expected_games: list[str],
+    expected_message: str,
+):
+    mocked_interaction.guild.id = guild_id
+    command = getattr(config_commands, command_name)
+
+    with patch.object(
+        config_commands,
+        "_has_config_permission",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch.object(
+        config_commands,
+        "_load_enabled_games",
+        new_callable=AsyncMock,
+        return_value=loaded_games,
+    ), patch.object(
+        config_commands,
+        "_update_enabled_games",
+        new_callable=AsyncMock,
+        return_value=stored_games,
+    ) as mock_update:
+        await command.callback(mocked_interaction, game)
+
+    mock_update.assert_awaited_once_with(guild_id, expected_games)
+    mocked_interaction.followup.send.assert_awaited_once_with(
+        expected_message,
+        ephemeral=True,
+    )
+
+
 @pytest.mark.asyncio
 async def test_view_formats_mentions_and_games(mocked_interaction):
     mocked_interaction.guild.id = 123
@@ -89,115 +128,55 @@ async def test_set_games_rejects_unsupported_slug(mocked_interaction):
 
 @pytest.mark.asyncio
 async def test_add_game_updates_enabled_games(mocked_interaction):
-    mocked_interaction.guild.id = 101
-
-    with patch.object(
-        config_commands,
-        "_has_config_permission",
-        new_callable=AsyncMock,
-        return_value=True,
-    ), patch.object(
-        config_commands,
-        "_load_enabled_games",
-        new_callable=AsyncMock,
-        return_value=["lol"],
-    ), patch.object(
-        config_commands,
-        "_update_enabled_games",
-        new_callable=AsyncMock,
-        return_value="lol,cs2",
-    ) as mock_update:
-        await config_commands.add_game.callback(mocked_interaction, "cs2")
-
-    mock_update.assert_awaited_once_with(101, ["lol", "cs2"])
-    mocked_interaction.followup.send.assert_awaited_once_with(
-        "Enabled games: LoL, CS2",
-        ephemeral=True,
+    await _assert_game_command_result(
+        mocked_interaction,
+        guild_id=101,
+        command_name="add_game",
+        game="cs2",
+        loaded_games=["lol"],
+        stored_games="lol,cs2",
+        expected_games=["lol", "cs2"],
+        expected_message="Enabled games: LoL, CS2",
     )
 
 
 @pytest.mark.asyncio
 async def test_add_game_handles_unset_enabled_games(mocked_interaction):
-    mocked_interaction.guild.id = 111
-
-    with patch.object(
-        config_commands,
-        "_has_config_permission",
-        new_callable=AsyncMock,
-        return_value=True,
-    ), patch.object(
-        config_commands,
-        "_load_enabled_games",
-        new_callable=AsyncMock,
-        return_value=None,
-    ), patch.object(
-        config_commands,
-        "_update_enabled_games",
-        new_callable=AsyncMock,
-        return_value="cs2",
-    ) as mock_update:
-        await config_commands.add_game.callback(mocked_interaction, "cs2")
-
-    mock_update.assert_awaited_once_with(111, ["cs2"])
-    mocked_interaction.followup.send.assert_awaited_once_with(
-        "Enabled games: CS2",
-        ephemeral=True,
+    await _assert_game_command_result(
+        mocked_interaction,
+        guild_id=111,
+        command_name="add_game",
+        game="cs2",
+        loaded_games=None,
+        stored_games="cs2",
+        expected_games=["cs2"],
+        expected_message="Enabled games: CS2",
     )
 
 
 @pytest.mark.asyncio
 async def test_remove_game_removes_enabled_slug(mocked_interaction):
-    mocked_interaction.guild.id = 202
-
-    with patch.object(
-        config_commands,
-        "_has_config_permission",
-        new_callable=AsyncMock,
-        return_value=True,
-    ), patch.object(
-        config_commands,
-        "_load_enabled_games",
-        new_callable=AsyncMock,
-        return_value=["lol", "cs2"],
-    ), patch.object(
-        config_commands,
-        "_update_enabled_games",
-        new_callable=AsyncMock,
-        return_value="lol",
-    ) as mock_update:
-        await config_commands.remove_game.callback(mocked_interaction, "cs2")
-
-    mock_update.assert_awaited_once_with(202, ["lol"])
-    mocked_interaction.followup.send.assert_awaited_once_with(
-        "Enabled games: LoL",
-        ephemeral=True,
+    await _assert_game_command_result(
+        mocked_interaction,
+        guild_id=202,
+        command_name="remove_game",
+        game="cs2",
+        loaded_games=["lol", "cs2"],
+        stored_games="lol",
+        expected_games=["lol"],
+        expected_message="Enabled games: LoL",
     )
 
 
 @pytest.mark.asyncio
 async def test_remove_game_filters_stale_games(mocked_interaction):
-    mocked_interaction.guild.id = 303
-
-    with patch.object(
-        config_commands,
-        "_has_config_permission",
-        new_callable=AsyncMock,
-        return_value=True,
-    ), patch.object(
-        config_commands,
-        "_load_enabled_games",
-        new_callable=AsyncMock,
-        return_value=["lol", "stale", "cs2"],
-    ), patch.object(
-        config_commands,
-        "_update_enabled_games",
-        new_callable=AsyncMock,
-        return_value="lol",
-    ) as mock_update:
-        await config_commands.remove_game.callback(mocked_interaction, "cs2")
-
-    mock_update.assert_awaited_once_with(303, ["lol"])
-    mocked_interaction.followup.send.assert_awaited_once_with(
-        "Enabled games: LoL",
-        ephemeral=True,
+    await _assert_game_command_result(
+        mocked_interaction,
+        guild_id=303,
+        command_name="remove_game",
+        game="cs2",
+        loaded_games=["lol", "stale", "cs2"],
+        stored_games="lol",
+        expected_games=["lol"],
+        expected_message="Enabled games: LoL",
     )

--- a/tests/commands/test_config.py
+++ b/tests/commands/test_config.py
@@ -93,3 +93,67 @@ async def test_set_games_rejects_unsupported_slug():
     interaction.followup.send.assert_awaited_once()
     message = interaction.followup.send.call_args.args[0]
     assert "Invalid games list." in message
+
+
+@pytest.mark.asyncio
+async def test_add_game_updates_enabled_games():
+    interaction = AsyncMock(spec=discord.Interaction)
+    interaction.guild = MagicMock(id=101)
+    interaction.response = AsyncMock()
+    interaction.followup = AsyncMock()
+
+    with patch.object(
+        config_commands,
+        "_has_config_permission",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch.object(
+        config_commands,
+        "_load_enabled_games",
+        new_callable=AsyncMock,
+        return_value=["lol"],
+    ), patch.object(
+        config_commands,
+        "_update_enabled_games",
+        new_callable=AsyncMock,
+        return_value="lol,cs2",
+    ) as mock_update:
+        await config_commands.add_game.callback(interaction, "cs2")
+
+    mock_update.assert_awaited_once_with(101, ["lol", "cs2"])
+    interaction.followup.send.assert_awaited_once_with(
+        "Enabled games: LoL, CS2",
+        ephemeral=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_remove_game_removes_enabled_slug():
+    interaction = AsyncMock(spec=discord.Interaction)
+    interaction.guild = MagicMock(id=202)
+    interaction.response = AsyncMock()
+    interaction.followup = AsyncMock()
+
+    with patch.object(
+        config_commands,
+        "_has_config_permission",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch.object(
+        config_commands,
+        "_load_enabled_games",
+        new_callable=AsyncMock,
+        return_value=["lol", "cs2"],
+    ), patch.object(
+        config_commands,
+        "_update_enabled_games",
+        new_callable=AsyncMock,
+        return_value="lol",
+    ) as mock_update:
+        await config_commands.remove_game.callback(interaction, "cs2")
+
+    mock_update.assert_awaited_once_with(202, ["lol"])
+    interaction.followup.send.assert_awaited_once_with(
+        "Enabled games: LoL",
+        ephemeral=True,
+    )

--- a/tests/commands/test_config.py
+++ b/tests/commands/test_config.py
@@ -1,0 +1,95 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+import src.commands.config as config_commands
+
+
+@pytest.mark.asyncio
+async def test_view_formats_mentions_and_games():
+    interaction = AsyncMock(spec=discord.Interaction)
+    interaction.guild = MagicMock(id=123)
+    interaction.response = AsyncMock()
+
+    cfg = MagicMock(
+        announcement_channel_id=111,
+        live_updates_channel_id=222,
+        enabled_games="lol,cs2",
+    )
+
+    with patch.object(
+        config_commands, "get_async_session"
+    ) as mock_session_factory, patch.object(
+        config_commands,
+        "get_guild_config_async",
+        new_callable=AsyncMock,
+        return_value=cfg,
+    ):
+        mock_session_factory.return_value.__aenter__.return_value = AsyncMock()
+        await config_commands.view.callback(interaction)
+
+    message = interaction.response.send_message.call_args.args[0]
+    assert "<#111>" in message
+    assert "<#222>" in message
+    assert "LoL, CS2" in message
+
+
+@pytest.mark.asyncio
+async def test_set_channel_updates_live_updates_field():
+    interaction = AsyncMock(spec=discord.Interaction)
+    interaction.guild = MagicMock(id=456)
+    interaction.response = AsyncMock()
+    interaction.followup = AsyncMock()
+
+    channel = MagicMock(id=999, mention="<#999>")
+    kind = discord.app_commands.Choice(
+        name="Live Updates",
+        value="live_updates",
+    )
+
+    with patch.object(
+        config_commands,
+        "_has_config_permission",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch.object(
+        config_commands,
+        "_update_guild_channel",
+        new_callable=AsyncMock,
+    ) as mock_update:
+        await config_commands.set_channel.callback(
+            interaction,
+            kind,
+            channel,
+        )
+
+    mock_update.assert_awaited_once_with(
+        interaction.guild.id,
+        "live_updates_channel_id",
+        channel.id,
+    )
+    interaction.followup.send.assert_awaited_once_with(
+        "Updated live updates channel to <#999>.",
+        ephemeral=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_set_games_rejects_unsupported_slug():
+    interaction = AsyncMock(spec=discord.Interaction)
+    interaction.guild = MagicMock(id=789)
+    interaction.response = AsyncMock()
+    interaction.followup = AsyncMock()
+
+    with patch.object(
+        config_commands,
+        "_has_config_permission",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        await config_commands.set_games.callback(interaction, "lol,badgame")
+
+    interaction.followup.send.assert_awaited_once()
+    message = interaction.followup.send.call_args.args[0]
+    assert "Invalid games list." in message

--- a/tests/test_live_messages.py
+++ b/tests/test_live_messages.py
@@ -8,7 +8,6 @@ import src.live_messages as live_messages
 
 @pytest.mark.asyncio
 async def test_refresh_scope_creates_missing_live_message():
-    session = AsyncMock()
     guild = MagicMock()
     guild.id = 111
     guild.me = None
@@ -29,7 +28,7 @@ async def test_refresh_scope_creates_missing_live_message():
 
     with patch.object(
         live_messages,
-        "get_live_message_async",
+        "_load_live_record",
         new_callable=AsyncMock,
         return_value=None,
     ), patch.object(
@@ -39,31 +38,32 @@ async def test_refresh_scope_creates_missing_live_message():
         return_value=embed,
     ), patch.object(
         live_messages,
-        "set_live_message_async",
+        "_persist_live_message_pointer",
         new_callable=AsyncMock,
-    ) as mock_set_live:
+    ) as mock_persist:
         await live_messages._refresh_guild_scope(
-            session,
-            guild,
             cfg,
-            "lol",
-            "upcoming",
+            live_messages.LiveMessageScope(
+                guild=guild,
+                game="lol",
+                scope="upcoming",
+            ),
         )
 
     channel.send.assert_awaited_once_with(embed=embed)
-    mock_set_live.assert_awaited_once_with(
-        session,
-        guild.id,
+    mock_persist.assert_awaited_once_with(
+        live_messages.LiveMessageScope(
+            guild=guild,
+            game="lol",
+            scope="upcoming",
+        ),
         channel.id,
         sent_message.id,
-        "upcoming",
-        "lol",
     )
 
 
 @pytest.mark.asyncio
 async def test_refresh_scope_edits_existing_live_message():
-    session = AsyncMock()
     guild = MagicMock()
     guild.id = 222
     guild.me = None
@@ -85,7 +85,7 @@ async def test_refresh_scope_edits_existing_live_message():
 
     with patch.object(
         live_messages,
-        "get_live_message_async",
+        "_load_live_record",
         new_callable=AsyncMock,
         return_value=live_record,
     ), patch.object(
@@ -95,26 +95,28 @@ async def test_refresh_scope_edits_existing_live_message():
         return_value=embed,
     ), patch.object(
         live_messages,
-        "set_live_message_async",
+        "_persist_live_message_pointer",
         new_callable=AsyncMock,
-    ) as mock_set_live:
+    ) as mock_persist:
         await live_messages._refresh_guild_scope(
-            session,
-            guild,
             cfg,
-            "lol",
-            "running",
+            live_messages.LiveMessageScope(
+                guild=guild,
+                game="lol",
+                scope="running",
+            ),
         )
 
     fetched_message.edit.assert_awaited_once_with(embed=embed)
     channel.send.assert_not_called()
-    mock_set_live.assert_awaited_once_with(
-        session,
-        guild.id,
+    mock_persist.assert_awaited_once_with(
+        live_messages.LiveMessageScope(
+            guild=guild,
+            game="lol",
+            scope="running",
+        ),
         channel.id,
         live_record.message_id,
-        "running",
-        "lol",
     )
 
 

--- a/tests/test_live_messages.py
+++ b/tests/test_live_messages.py
@@ -1,9 +1,12 @@
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
 import pytest
+from sqlmodel import SQLModel, Session, create_engine
 
 import src.live_messages as live_messages
+from src.models import Contest, Match, Result
 
 
 @pytest.mark.asyncio
@@ -125,3 +128,82 @@ def test_build_running_embed_keeps_empty_state_message():
 
     assert embed.title == "LoL Live Matches"
     assert embed.description == "No matches are currently live."
+
+
+@pytest.mark.asyncio
+async def test_fetch_running_matches_excludes_finished_results():
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        contest = Contest(
+            pandascore_league_id=1,
+            pandascore_serie_id=2,
+            name="LCS Spring",
+            start_date=datetime.now(timezone.utc),
+            end_date=datetime.now(timezone.utc),
+        )
+        session.add(contest)
+        session.commit()
+        session.refresh(contest)
+
+        running_match = Match(
+            contest_id=contest.id,
+            pandascore_id=1,
+            team1="A",
+            team2="B",
+            status="running",
+            game="lol",
+            scheduled_time=datetime.now(timezone.utc),
+        )
+        stale_match = Match(
+            contest_id=contest.id,
+            pandascore_id=2,
+            team1="C",
+            team2="D",
+            status="running",
+            game="lol",
+            scheduled_time=datetime.now(timezone.utc),
+        )
+        session.add(running_match)
+        session.add(stale_match)
+        session.commit()
+        session.refresh(running_match)
+        session.refresh(stale_match)
+
+        session.add(
+            Result(
+                match_id=stale_match.id,
+                winner="C",
+                score="2-0",
+            )
+        )
+        session.commit()
+
+    class _ResultWrapper:
+        def __init__(self, rows):
+            self._rows = rows
+
+        def all(self):
+            return self._rows
+
+    class _AsyncSession:
+        async def exec(self, stmt):
+            with Session(engine) as session:
+                return _ResultWrapper(list(session.exec(stmt).all()))
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            _ = (exc_type, exc, tb)
+            return False
+
+    with patch.object(
+        live_messages,
+        "get_async_session",
+        return_value=_AsyncSession(),
+    ):
+        matches = await live_messages._fetch_running_matches("lol")
+
+    assert [match.pandascore_id for match in matches] == [1]

--- a/tests/test_live_messages.py
+++ b/tests/test_live_messages.py
@@ -1,236 +1,125 @@
-from dataclasses import dataclass
-from datetime import datetime, timezone
-import pytest
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import src.notification_batcher as nb
-import src.notification_delivery as delivery
-from src.notification_batcher import NotificationBatcher
-from src.models import Match, Contest
+import discord
+import pytest
 
-
-@dataclass
-class _SessionMocks:
-    batcher: AsyncMock
-    delivery: AsyncMock
-
-
-@dataclass
-class _FetchMocks:
-    matches: AsyncMock
-    teams: AsyncMock
-    resolver: MagicMock
-
-
-@dataclass
-class _BatcherMockBundle:
-    sessions: _SessionMocks
-    fetchers: _FetchMocks
-
-
-def _build_live_message_test_match(match_id: int) -> Match:
-    now = datetime.now(timezone.utc)
-    contest = Contest(name="C1", image_url=None, start_date=now, end_date=now)
-    match = Match(
-        id=match_id,
-        team1="A" if match_id == 1 else "X",
-        team2="B" if match_id == 1 else "Y",
-        scheduled_time=now,
-        contest_id=1,
-        game="lol",
-    )
-    match.contest = contest
-    return match
-
-
-def _configure_batcher_mocks(
-    bundle: _BatcherMockBundle,
-    mock_session,
-    match,
-) -> None:
-    bundle.sessions.batcher.return_value.__aenter__.return_value = mock_session
-    bundle.sessions.delivery.return_value.__aenter__.return_value = (
-        mock_session
-    )
-    bundle.fetchers.matches.return_value = [match]
-    bundle.fetchers.teams.return_value = {}
-    bundle.fetchers.resolver.return_value = (None, None)
+import src.live_messages as live_messages
 
 
 @pytest.mark.asyncio
-async def test_scoped_live_message_editing_and_creation():
-    """Verify that the batcher will attempt to edit an existing live message
-    for a guild scoped to (scope_type, game_slug) and will create/persist a
-    new message pointer when none exists.
-    """
-    batcher = NotificationBatcher()
-
-    # Prepare mocks
-    mock_bot = MagicMock()
+async def test_refresh_scope_creates_missing_live_message():
+    session = AsyncMock()
     guild = MagicMock()
     guild.id = 111
-    guild.text_channels = []
-    # Simulate guild.get_channel and fetch_channel
+    guild.me = None
+
     channel = AsyncMock()
     channel.id = 222
-    channel.send = AsyncMock()
+    sent_message = AsyncMock()
+    sent_message.id = 333
+    channel.send.return_value = sent_message
 
-    # Create a fake message object returned by channel.send
-    fake_msg = AsyncMock()
-    fake_msg.id = 333
-    channel.send.return_value = fake_msg
-
-    mock_bot.guilds = [guild]
     guild.get_channel.return_value = channel
-
-    # Mock DB session to initially return no live message, then ensure set is called
-    mock_session = AsyncMock()
-
-    match = _build_live_message_test_match(1)
-
-    # Patch get_bot_instance and session helpers and bulk fetches
-    cfg_obj = MagicMock()
-    cfg_obj.live_updates_channel_id = channel.id
-    cfg_obj.enabled_games = None
+    cfg = MagicMock(
+        live_updates_channel_id=channel.id,
+        announcement_channel_id=None,
+        enabled_games="lol",
+    )
+    embed = discord.Embed(title="Upcoming")
 
     with patch.object(
-        nb, "get_bot_instance", return_value=mock_bot
-    ), patch.object(
-        nb, "get_async_session"
-    ) as mock_batcher_session_cls, patch.object(
-        delivery, "get_async_session"
-    ) as mock_delivery_session_cls, patch.object(
-        nb, "_bulk_fetch_matches", new_callable=AsyncMock
-    ) as mock_bulk_matches, patch.object(
-        nb, "_bulk_fetch_teams", new_callable=AsyncMock
-    ) as mock_bulk_teams, patch.object(
-        nb, "_resolve_teams"
-    ) as mock_resolve_teams, patch.object(
-        delivery, "set_live_message_async", new_callable=AsyncMock
-    ) as mock_set_live_message, patch.object(
-        delivery,
-        "get_guild_config_async",
-        new_callable=AsyncMock,
-        return_value=cfg_obj,
-    ), patch.object(
-        delivery,
+        live_messages,
         "get_live_message_async",
         new_callable=AsyncMock,
         return_value=None,
-    ):
-        bundle = _BatcherMockBundle(
-            sessions=_SessionMocks(
-                batcher=mock_batcher_session_cls,
-                delivery=mock_delivery_session_cls,
-            ),
-            fetchers=_FetchMocks(
-                matches=mock_bulk_matches,
-                teams=mock_bulk_teams,
-                resolver=mock_resolve_teams,
-            ),
+    ), patch.object(
+        live_messages,
+        "_build_live_message_embed",
+        new_callable=AsyncMock,
+        return_value=embed,
+    ), patch.object(
+        live_messages,
+        "set_live_message_async",
+        new_callable=AsyncMock,
+    ) as mock_set_live:
+        await live_messages._refresh_guild_scope(
+            session,
+            guild,
+            cfg,
+            "lol",
+            "upcoming",
         )
 
-        _configure_batcher_mocks(
-            bundle,
-            mock_session,
-            match,
-        )
-
-        # Trigger a reminder (mapped to upcoming scope)
-        await batcher.add_reminder(match.id, 5)
-
-        # Wait for debounce flush
-        await asyncio.sleep(1.1)
-
-        # Assert channel.send was called (no existing live message existed)
-        assert channel.send.await_count >= 1
-        # Ensure we persisted the live message pointer for the guild/scope
-        assert mock_set_live_message.await_count >= 1
+    channel.send.assert_awaited_once_with(embed=embed)
+    mock_set_live.assert_awaited_once_with(
+        session,
+        guild.id,
+        channel.id,
+        sent_message.id,
+        "upcoming",
+        "lol",
+    )
 
 
 @pytest.mark.asyncio
-async def test_mid_series_updates_edit_existing_message():
-    """When a live (running) message exists, mid-series updates should edit
-    the existing message rather than sending a new one.
-    """
-    batcher = NotificationBatcher()
-
-    mock_bot = MagicMock()
+async def test_refresh_scope_edits_existing_live_message():
+    session = AsyncMock()
     guild = MagicMock()
-    guild.id = 2222
-    channel = MagicMock()
-    channel.id = 4444
+    guild.id = 222
+    guild.me = None
 
-    # Simulate existing live message record and message fetch/edit
-    live_rec = MagicMock()
-    live_rec.channel_id = channel.id
-    live_rec.message_id = 5555
+    channel = AsyncMock()
+    channel.id = 444
+    fetched_message = AsyncMock()
+    fetched_message.id = 555
+    channel.fetch_message.return_value = fetched_message
 
-    # make channel.fetch_message return an object with edit coroutine
-    fetched_msg = AsyncMock()
-    fetched_msg.edit = AsyncMock()
-    channel.fetch_message = AsyncMock(return_value=fetched_msg)
-
-    mock_bot.guilds = [guild]
     guild.get_channel.return_value = channel
-
-    mock_session = AsyncMock()
-
-    match = _build_live_message_test_match(11)
+    cfg = MagicMock(
+        live_updates_channel_id=channel.id,
+        announcement_channel_id=None,
+        enabled_games="lol",
+    )
+    live_record = MagicMock(channel_id=channel.id, message_id=555)
+    embed = discord.Embed(title="Running")
 
     with patch.object(
-        nb, "get_bot_instance", return_value=mock_bot
+        live_messages,
+        "get_live_message_async",
+        new_callable=AsyncMock,
+        return_value=live_record,
     ), patch.object(
-        nb, "get_async_session"
-    ) as mock_batcher_session_cls, patch.object(
-        delivery, "get_async_session"
-    ) as mock_delivery_session_cls, patch.object(
-        nb, "_bulk_fetch_matches", new_callable=AsyncMock
-    ) as mock_bulk_matches, patch.object(
-        nb, "_bulk_fetch_teams", new_callable=AsyncMock
-    ) as mock_bulk_teams, patch.object(
-        nb, "_resolve_teams"
-    ) as mock_resolve_teams, patch.object(
-        delivery, "get_live_message_async", new_callable=AsyncMock
-    ) as mock_get_live, patch.object(
-        delivery, "set_live_message_async", new_callable=AsyncMock
+        live_messages,
+        "_build_live_message_embed",
+        new_callable=AsyncMock,
+        return_value=embed,
+    ), patch.object(
+        live_messages,
+        "set_live_message_async",
+        new_callable=AsyncMock,
     ) as mock_set_live:
-        # Provide a guild config so per-guild channel resolution works in tests
-        with patch.object(
-            delivery,
-            "get_guild_config_async",
-            new_callable=AsyncMock,
-            return_value=MagicMock(
-                live_updates_channel_id=channel.id,
-                enabled_games=None,
-            ),
-        ):
-            bundle = _BatcherMockBundle(
-                sessions=_SessionMocks(
-                    batcher=mock_batcher_session_cls,
-                    delivery=mock_delivery_session_cls,
-                ),
-                fetchers=_FetchMocks(
-                    matches=mock_bulk_matches,
-                    teams=mock_bulk_teams,
-                    resolver=mock_resolve_teams,
-                ),
-            )
+        await live_messages._refresh_guild_scope(
+            session,
+            guild,
+            cfg,
+            "lol",
+            "running",
+        )
 
-            _configure_batcher_mocks(
-                bundle,
-                mock_session,
-                match,
-            )
+    fetched_message.edit.assert_awaited_once_with(embed=embed)
+    channel.send.assert_not_called()
+    mock_set_live.assert_awaited_once_with(
+        session,
+        guild.id,
+        channel.id,
+        live_record.message_id,
+        "running",
+        "lol",
+    )
 
-            mock_get_live.return_value = live_rec
 
-            # Trigger mid-series update (mapped to running scope)
-            await batcher.add_mid_series_update(match.id, "1-0")
-            await asyncio.sleep(1.1)
+def test_build_running_embed_keeps_empty_state_message():
+    embed = live_messages._build_running_embed("lol", [])
 
-            # Expect we edited the existing message
-            fetched_msg.edit.assert_awaited()
-            # And did not call set_live_message since pointer already existed
-            assert mock_set_live.await_count == 0
+    assert embed.title == "LoL Live Matches"
+    assert embed.description == "No matches are currently live."

--- a/tests/test_notification_batcher.py
+++ b/tests/test_notification_batcher.py
@@ -3,7 +3,6 @@ import asyncio
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 import src.notification_batcher
-import src.notification_delivery
 from src.notification_batcher import NotificationBatcher
 from src.models import Match, Contest
 
@@ -22,28 +21,18 @@ async def test_batch_reminders():
     ), patch.object(
         src.notification_batcher, "get_async_session"
     ) as mock_batcher_session_cls, patch.object(
-        src.notification_delivery, "get_async_session"
-    ) as mock_delivery_session_cls, patch.object(
-        src.notification_delivery,
-        "broadcast_embed_to_guilds",
+        src.notification_batcher,
+        "refresh_live_messages_for_games",
         new_callable=AsyncMock,
-    ) as mock_broadcast, patch.object(
+    ) as mock_refresh, patch.object(
         src.notification_batcher, "_bulk_fetch_matches", new_callable=AsyncMock
     ) as mock_bulk_matches, patch.object(
         src.notification_batcher, "_bulk_fetch_teams", new_callable=AsyncMock
     ) as mock_bulk_teams, patch.object(
         src.notification_batcher, "_resolve_teams"
-    ) as mock_resolve_teams, patch.object(
-        src.notification_delivery,
-        "get_guild_config_async",
-        new_callable=AsyncMock,
-        return_value=None,
-    ):
+    ) as mock_resolve_teams:
 
         mock_batcher_session_cls.return_value.__aenter__.return_value = (
-            mock_session
-        )
-        mock_delivery_session_cls.return_value.__aenter__.return_value = (
             mock_session
         )
 
@@ -82,12 +71,7 @@ async def test_batch_reminders():
         assert len(batcher._pending["reminder_5"]) == 2
         await asyncio.sleep(1.1)
 
-        assert mock_broadcast.call_count == 1
-        args, _ = mock_broadcast.call_args
-        embed = args[1]
-        assert "Team A" in embed.description
-        assert "Team C" in embed.description
-        assert embed.thumbnail.url == "http://example.com/icon.png"
+        mock_refresh.assert_awaited_once_with({"lol"})
 
 
 @pytest.mark.asyncio
@@ -101,12 +85,10 @@ async def test_batch_results():
     ), patch.object(
         src.notification_batcher, "get_async_session"
     ) as mock_batcher_session_cls, patch.object(
-        src.notification_delivery, "get_async_session"
-    ) as mock_delivery_session_cls, patch.object(
-        src.notification_delivery,
-        "broadcast_embed_to_guilds",
+        src.notification_batcher,
+        "refresh_live_messages_for_games",
         new_callable=AsyncMock,
-    ) as mock_broadcast, patch.object(
+    ) as mock_refresh, patch.object(
         src.notification_batcher, "_bulk_fetch_matches", new_callable=AsyncMock
     ) as mock_bulk_matches, patch.object(
         src.notification_batcher, "_bulk_fetch_teams", new_callable=AsyncMock
@@ -119,9 +101,6 @@ async def test_batch_results():
     ) as mock_resolve_teams:
 
         mock_batcher_session_cls.return_value.__aenter__.return_value = (
-            mock_session
-        )
-        mock_delivery_session_cls.return_value.__aenter__.return_value = (
             mock_session
         )
         now = datetime.now(timezone.utc)
@@ -161,11 +140,7 @@ async def test_batch_results():
 
         await asyncio.sleep(1.1)
 
-        assert mock_broadcast.call_count == 1
-        args, _ = mock_broadcast.call_args
-        embed = args[1]
-        assert "A" in embed.fields[0].value
-        assert "D" in embed.fields[1].value
+        mock_refresh.assert_awaited_once_with({"lol"})
 
 
 @pytest.mark.asyncio
@@ -178,12 +153,10 @@ async def test_explicit_batching_mode():
     ), patch.object(
         src.notification_batcher, "get_async_session"
     ) as mock_batcher_session_cls, patch.object(
-        src.notification_delivery, "get_async_session"
-    ) as mock_delivery_session_cls, patch.object(
-        src.notification_delivery,
-        "broadcast_embed_to_guilds",
+        src.notification_batcher,
+        "refresh_live_messages_for_games",
         new_callable=AsyncMock,
-    ) as mock_broadcast, patch.object(
+    ) as mock_refresh, patch.object(
         src.notification_batcher, "_bulk_fetch_matches", new_callable=AsyncMock
     ) as mock_bulk_matches, patch.object(
         src.notification_batcher, "_bulk_fetch_teams", new_callable=AsyncMock
@@ -194,13 +167,18 @@ async def test_explicit_batching_mode():
         mock_batcher_session_cls.return_value.__aenter__.return_value = (
             mock_session
         )
-        mock_delivery_session_cls.return_value.__aenter__.return_value = (
-            mock_session
-        )
 
-        match1 = MagicMock(id=1, scheduled_time=datetime.now(timezone.utc))
+        match1 = MagicMock(
+            id=1,
+            scheduled_time=datetime.now(timezone.utc),
+            game="lol",
+        )
         match1.contest = MagicMock(image_url=None)
-        match2 = MagicMock(id=2, scheduled_time=datetime.now(timezone.utc))
+        match2 = MagicMock(
+            id=2,
+            scheduled_time=datetime.now(timezone.utc),
+            game="lol",
+        )
         match2.contest = MagicMock(image_url=None)
 
         mock_bulk_matches.return_value = [match1, match2]
@@ -210,9 +188,9 @@ async def test_explicit_batching_mode():
         async with batcher.batching():
             await batcher.add_reminder(1, 5)
             await asyncio.sleep(1.1)
-            assert mock_broadcast.call_count == 0
+            assert mock_refresh.call_count == 0
             assert len(batcher._pending["reminder_5"]) == 1
             await batcher.add_reminder(2, 5)
 
-        assert mock_broadcast.call_count == 1
+        mock_refresh.assert_awaited_once_with({"lol"})
         assert len(batcher._pending["reminder_5"]) == 0

--- a/tests/test_pandascore.py
+++ b/tests/test_pandascore.py
@@ -264,9 +264,8 @@ class TestPandaScoreSyncIntegration:
             new_callable=AsyncMock,
             return_value=[],
         ), patch(
-            "src.pandascore_sync.pandascore_client.fetch_running_matches",
+            "src.pandascore_sync._reconcile_finished_matches_for_game",
             new_callable=AsyncMock,
-            return_value=[],
         ):
             result = await perform_pandascore_sync()
             assert result is not None
@@ -283,9 +282,74 @@ class TestPandaScoreSyncIntegration:
             "src.pandascore_sync.pandascore_client.fetch_matches",
             new_callable=AsyncMock,
             side_effect=Exception("API Error"),
+        ), patch(
+            "src.pandascore_sync._reconcile_finished_matches_for_game",
+            new_callable=AsyncMock,
         ):
             result = await perform_pandascore_sync()
             assert result is None
+
+    @pytest.mark.asyncio
+    async def test_perform_pandascore_sync_fetches_all_configured_games(self):
+        from src.pandascore_sync import perform_pandascore_sync
+
+        async def _fetch_matches(kind, options=None, game="lol"):
+            _ = options
+            if kind == "running":
+                return []
+            if kind == "recent_past":
+                return []
+            return [
+                {
+                    "id": 100 if game == "lol" else 200,
+                    "scheduled_at": "2024-03-15T10:00:00Z",
+                    "number_of_games": 3,
+                    "status": "not_started",
+                    "league": {"id": 1, "name": "League"},
+                    "serie": {
+                        "id": 10,
+                        "name": "Split",
+                        "full_name": "Split",
+                    },
+                    "opponents": [
+                        {
+                            "opponent": {
+                                "id": 1,
+                                "name": f"{game} A",
+                            }
+                        },
+                        {
+                            "opponent": {
+                                "id": 2,
+                                "name": f"{game} B",
+                            }
+                        },
+                    ],
+                    "videogame": {"slug": game},
+                }
+            ]
+
+        with patch(
+            "src.pandascore_sync.pandascore_client.fetch_matches",
+            new_callable=AsyncMock,
+            side_effect=_fetch_matches,
+        ) as mock_fetch, patch(
+            "src.pandascore_sync._run_post_sync_actions",
+            new_callable=AsyncMock,
+        ), patch(
+            "src.pandascore_sync._reconcile_finished_matches_for_game",
+            new_callable=AsyncMock,
+        ), patch(
+            "src.config.DEFAULT_GAMES",
+            ["lol", "cs2"],
+        ):
+            result = await perform_pandascore_sync()
+
+        requested_games = {
+            call.kwargs["game"] for call in mock_fetch.await_args_list
+        }
+        assert requested_games == {"lol", "cs2"}
+        assert result is not None
 
 
 class TestPandaScoreClientRateLimiting:

--- a/tests/test_polling_logic.py
+++ b/tests/test_polling_logic.py
@@ -16,6 +16,7 @@ async def test_poll_live_match_job_mid_series_update():
     mock_match = Match(
         id=1,
         pandascore_id=123,
+        game="cs2",
         team1="Team A",
         team2="Team B",
         team1_id=100,
@@ -69,7 +70,7 @@ async def test_poll_live_match_job_mid_series_update():
 
         # Assert
         mock_get_match.assert_awaited_once_with(mock_session, 1)
-        mock_get_match_data.assert_awaited_once_with(123)
+        mock_get_match_data.assert_awaited_once_with(123, game="cs2")
         mock_send_update.assert_awaited_once()
         mock_send_result.assert_not_called()
         mock_remove_job.assert_not_called()
@@ -87,6 +88,7 @@ async def test_poll_live_match_job_final_result():
     mock_match = Match(
         id=2,
         pandascore_id=456,
+        game="cs2",
         team1="Team A",
         team2="Team B",
         team1_id=100,
@@ -150,7 +152,7 @@ async def test_poll_live_match_job_final_result():
 
         # Assert
         mock_get_match.assert_awaited_once_with(mock_session, 2)
-        mock_get_match_data.assert_awaited_once_with(456)
+        mock_get_match_data.assert_awaited_once_with(456, game="cs2")
         mock_send_update.assert_not_called()
         mock_send_result.assert_awaited_once()
         mock_remove_job.assert_called_once()
@@ -166,6 +168,7 @@ async def test_poll_live_match_job_no_score_change():
     mock_match = Match(
         id=3,
         pandascore_id=789,
+        game="cs2",
         team1="Team A",
         team2="Team B",
         team1_id=100,
@@ -218,7 +221,7 @@ async def test_poll_live_match_job_no_score_change():
 
         # Assert
         mock_get_match.assert_awaited_once_with(mock_session, 3)
-        mock_get_match_data.assert_awaited_once_with(789)
+        mock_get_match_data.assert_awaited_once_with(789, game="cs2")
         mock_send_update.assert_not_called()
         mock_send_result.assert_not_called()
         mock_remove_job.assert_not_called()


### PR DESCRIPTION
## Summary

- restore correct multi-game PandaScore sync and polling behavior for CS2 and LoL
- add Discord-native config commands for adding and removing enabled games
- reconcile stale running matches so finished matches stop appearing in live messages

## Verification

- black --check src tests alembic
- flake8 src tests alembic --jobs=1
- python -m pytest