### PR TITLE
[codex] fix CS2 PandaScore routing

### DIFF
--- a/src/pandascore_client.py
+++ b/src/pandascore_client.py
@@ -25,6 +25,12 @@ JSONType = Union[Dict[str, Any], List[Any], str, int, float, bool, None]
 BASE_URL = "https://api.pandascore.co"
 DEFAULT_PAGE_SIZE = 50
 MAX_PAGE_SIZE = 100
+GAME_ROUTE_MAP = {
+    "cs2": "csgo",
+}
+GAME_QUERY_FILTERS = {
+    "cs2": {"filter[videogame_title]": "cs-2"},
+}
 
 # Rate limit: 1,000 requests/hour = ~16.7 req/min
 # We'll be conservative and track our usage
@@ -376,6 +382,23 @@ class PandaScoreClient:
             description = desc_template.format(page=opts.get("page", 1))
         return params, description
 
+    @staticmethod
+    def _resolve_game_route(game: str) -> str:
+        normalized = (game or "lol").lower()
+        return GAME_ROUTE_MAP.get(normalized, normalized)
+
+    @staticmethod
+    def _apply_game_filters(
+        params: Dict[str, Any], game: str
+    ) -> Dict[str, Any]:
+        normalized = (game or "lol").lower()
+        filters = GAME_QUERY_FILTERS.get(normalized, {})
+        if not filters:
+            return params
+        merged = dict(params)
+        merged.update(filters)
+        return merged
+
     async def fetch_matches(
         self,
         kind: str,
@@ -391,17 +414,27 @@ class PandaScoreClient:
         """
         opts = options or {}
         k = (kind or "").lower()
-        g = (game or "lol").lower()
+        normalized_game = (game or "lol").lower()
+        route_game = self._resolve_game_route(normalized_game)
 
         # Endpoint selection mapping
         mapping = {
             "upcoming": (
-                f"/{g}/matches/upcoming",
-                f"upcoming {g} matches (page {{page}})",
+                f"/{route_game}/matches/upcoming",
+                f"upcoming {normalized_game} matches (page {{page}})",
             ),
-            "recent_past": (f"/{g}/matches/past", f"recent past {g} matches"),
-            "past": (f"/{g}/matches/past", f"past {g} matches"),
-            "running": (f"/{g}/matches/running", f"running {g} matches"),
+            "recent_past": (
+                f"/{route_game}/matches/past",
+                f"recent past {normalized_game} matches",
+            ),
+            "past": (
+                f"/{route_game}/matches/past",
+                f"past {normalized_game} matches",
+            ),
+            "running": (
+                f"/{route_game}/matches/running",
+                f"running {normalized_game} matches",
+            ),
         }
 
         entry = mapping.get(k)
@@ -412,6 +445,7 @@ class PandaScoreClient:
         params, description = self._prepare_fetch_context(
             k, opts, desc_template
         )
+        params = self._apply_game_filters(params, normalized_game)
 
         return await self._fetch_matches(endpoint, params, description)
 
@@ -519,7 +553,10 @@ class PandaScoreClient:
             Match object or None if not found
         """
         try:
-            result = await self._make_request(f"/{game}/matches/{match_id}")
+            route_game = self._resolve_game_route(game)
+            result = await self._make_request(
+                f"/{route_game}/matches/{match_id}"
+            )
             logger.debug(
                 "Fetched match %d: status=%s", match_id, result.get("status")
             )

--- a/src/pandascore_sync.py
+++ b/src/pandascore_sync.py
@@ -9,8 +9,9 @@ import asyncio
 import logging
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 
+from sqlalchemy.exc import OperationalError
 from sqlmodel import select
-from src.models import Match, Result
+from src.models import GuildConfig, Match, Result
 from src.pandascore_client import (
     pandascore_client,
     DEFAULT_PAGE_SIZE,
@@ -39,17 +40,62 @@ from src.parsers.factory import get_parser, get_supported_game_slugs
 logger = logging.getLogger(__name__)
 
 
-def _configured_sync_games(requested_game: Optional[str] = None) -> list[str]:
+def _normalize_enabled_game(
+    raw_game: str,
+    supported: set[str],
+    seen: set[str],
+) -> Optional[str]:
+    game = raw_game.strip().lower()
+    if not game or game in seen:
+        return None
+    if game not in supported:
+        return None
+    return game
+
+
+def _parse_enabled_games(raw_games: Optional[str]) -> list[str]:
+    if raw_games is None:
+        return []
+
+    supported = set(get_supported_game_slugs())
+    normalized = []
+    seen = set()
+    for raw in raw_games.split(","):
+        game = _normalize_enabled_game(raw, supported, seen)
+        if game is None:
+            continue
+        seen.add(game)
+        normalized.append(game)
+    return normalized
+
+
+async def _configured_sync_games(
+    requested_game: Optional[str] = None,
+) -> list[str]:
     if requested_game:
         return [requested_game]
 
     from src.config import DEFAULT_GAMES
 
     supported = set(get_supported_game_slugs())
-    configured = [
+    configured = {
         game for game in (DEFAULT_GAMES or ["lol"]) if game in supported
+    }
+
+    try:
+        async with get_async_session() as db_session:
+            rows = await db_session.exec(select(GuildConfig.enabled_games))
+            for raw_games in rows.all():
+                configured.update(_parse_enabled_games(raw_games))
+    except OperationalError:
+        logger.warning(
+            "Guild configuration table unavailable; using default sync games."
+        )
+
+    ordered = [
+        game for game in get_supported_game_slugs() if game in configured
     ]
-    return configured or ["lol"]
+    return ordered or ["lol"]
 
 
 async def _run_post_sync_actions(
@@ -146,10 +192,21 @@ async def _fetch_matches_for_sync(
         upcoming, running, past = await asyncio.gather(
             upcoming_coro, running_coro, past_coro
         )
+        logger.info(
+            "Fetched %s matches from PandaScore: %d upcoming, %d running, "
+            "%d recent past",
+            game_slug,
+            len(upcoming),
+            len(running),
+            len(past),
+        )
 
         return upcoming + running + past
     except Exception:
-        logger.exception("Failed to fetch matches from PandaScore")
+        logger.exception(
+            "Failed to fetch matches from PandaScore for %s",
+            game_slug,
+        )
         return None
 
 
@@ -239,12 +296,14 @@ async def perform_pandascore_sync(
     notifications: List[Tuple[int, int]] = []
     time_changes: List[Tuple[Any, Any, Any]] = []
     failed_games: List[str] = []
+    completed_games = 0
 
-    for game_slug in _configured_sync_games(game):
+    for game_slug in await _configured_sync_games(game):
         matches_data = await _fetch_matches_for_sync(league_ids, game_slug)
         if matches_data is None:
             failed_games.append(game_slug)
             continue
+        completed_games += 1
         if not matches_data:
             logger.info("No %s matches found from PandaScore", game_slug)
             await _reconcile_finished_matches_for_game(game_slug)
@@ -282,7 +341,8 @@ async def perform_pandascore_sync(
             "PandaScore sync failed for games: %s",
             ", ".join(failed_games),
         )
-        return None
+        if completed_games == 0:
+            return None
     return total_summary
 
 
@@ -300,7 +360,8 @@ async def sync_running_matches() -> Dict[str, Any]:
 
     started = []
     finished = []
-    for game_slug in _configured_sync_games():
+    error = False
+    for game_slug in await _configured_sync_games():
         try:
             running_matches = await pandascore_client.fetch_running_matches(
                 game=game_slug
@@ -309,7 +370,8 @@ async def sync_running_matches() -> Dict[str, Any]:
             logger.exception(
                 "Failed to fetch running matches for %s", game_slug
             )
-            return {"started": [], "finished": [], "error": True}
+            error = True
+            continue
 
         async with get_async_session() as db_session:
             for match_data in running_matches:
@@ -335,7 +397,7 @@ async def sync_running_matches() -> Dict[str, Any]:
         len(started),
         len(finished),
     )
-    return {"started": started, "finished": finished}
+    return {"started": started, "finished": finished, "error": error}
 
 
 def _resolve_match_game(match, match_data: Dict[str, Any]) -> str:
@@ -343,10 +405,22 @@ def _resolve_match_game(match, match_data: Dict[str, Any]) -> str:
         return match.game
 
     videogame = match_data.get("videogame") or {}
-    if videogame.get("slug"):
-        return videogame["slug"]
+    slug = (videogame.get("slug") or "").lower()
+    title = (match_data.get("videogame_title") or "").lower()
+    if slug in {"cs2", "csgo", "counterstrike", "counter-strike"}:
+        return "cs2"
+    if "counter-strike 2" in title or title == "cs2":
+        return "cs2"
+    if slug:
+        return slug
 
-    return _configured_sync_games()[0]
+    from src.config import DEFAULT_GAMES
+
+    supported = set(get_supported_game_slugs())
+    for game_slug in DEFAULT_GAMES or ["lol"]:
+        if game_slug in supported:
+            return game_slug
+    return "lol"
 
 
 async def fetch_and_update_match_result(

--- a/src/parsers/cs2.py
+++ b/src/parsers/cs2.py
@@ -27,8 +27,22 @@ def _team_display_name(team_info: dict[str, Any]) -> str:
     return team_info.get("name") or team_info.get("acronym") or "TBD"
 
 
+def _normalize_cs2_game_slug(match_data: dict[str, Any]) -> Optional[str]:
+    videogame = match_data.get("videogame") or {}
+    slug = (videogame.get("slug") or "").strip().lower()
+    title = (match_data.get("videogame_title") or "").strip().lower()
+
+    if slug in {"cs2", "csgo", "counterstrike", "counter-strike"}:
+        return "cs2"
+    if "counter-strike 2" in title or title == "cs2":
+        return "cs2"
+    if slug:
+        return slug
+    return None
+
+
 def _match_game_slug(match_data: dict[str, Any]) -> str:
-    return (match_data.get("videogame") or {}).get("slug") or "cs2"
+    return _normalize_cs2_game_slug(match_data) or "cs2"
 
 
 class CS2Parser(PandaScoreParser):

--- a/tests/test_pandascore.py
+++ b/tests/test_pandascore.py
@@ -170,12 +170,12 @@ class TestLoLParser:
             "id": 123456,
             "scheduled_at": "2024-03-15T10:00:00Z",
             "opponents": [],
-            "videogame": {"slug": "cs2"},
+            "videogame": {"slug": "lol"},
         }
 
         result = parser.extract_match_data(match_data, contest_id=1)
         assert result is not None
-        assert result["game"] == "cs2"
+        assert result["game"] == "lol"
 
     def test_extract_match_data_missing_opponents(self, parser):
         """Test extracting match data with fewer than 2 opponents."""
@@ -289,6 +289,21 @@ class TestCS2Parser:
         assert result is not None
         assert result["game"] == "cs2"
 
+    @staticmethod
+    def test_extract_match_data_normalizes_counterstrike_payload(parser):
+        match_data = {
+            "id": 987654,
+            "scheduled_at": "2024-03-15T10:00:00Z",
+            "status": "not_started",
+            "opponents": [],
+            "videogame": {"slug": "counterstrike"},
+            "videogame_title": "Counter-Strike 2",
+        }
+
+        result = parser.extract_match_data(match_data, contest_id=1)
+        assert result is not None
+        assert result["game"] == "cs2"
+
 
 class TestPandaScoreSyncIntegration:
     """Integration tests for PandaScore sync (mocked API)."""
@@ -390,9 +405,96 @@ class TestPandaScoreSyncIntegration:
         assert requested_games == {"lol", "cs2"}
         assert result is not None
 
+    @pytest.mark.asyncio
+    async def test_perform_pandascore_sync_includes_guild_enabled_games(self):
+        from src.pandascore_sync import perform_pandascore_sync
+
+        class _ResultWrapper:
+            def __init__(self, rows):
+                self._rows = rows
+
+            def all(self):
+                return self._rows
+
+        class _AsyncSession:
+            @staticmethod
+            async def exec(stmt):
+                _ = stmt
+                return _ResultWrapper(["cs2"])
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                _ = (exc_type, exc, tb)
+                return False
+
+        async def _fetch_matches(kind, options=None, game="lol"):
+            _ = (kind, options)
+            return []
+
+        with patch(
+            "src.pandascore_sync.get_async_session",
+            return_value=_AsyncSession(),
+        ), patch(
+            "src.pandascore_sync.pandascore_client.fetch_matches",
+            new_callable=AsyncMock,
+            side_effect=_fetch_matches,
+        ) as mock_fetch, patch(
+            "src.pandascore_sync._run_post_sync_actions",
+            new_callable=AsyncMock,
+        ), patch(
+            "src.pandascore_sync._reconcile_finished_matches_for_game",
+            new_callable=AsyncMock,
+        ), patch(
+            "src.config.DEFAULT_GAMES",
+            ["lol"],
+        ):
+            await perform_pandascore_sync()
+
+        requested_games = {
+            call.kwargs["game"] for call in mock_fetch.await_args_list
+        }
+        assert requested_games == {"lol", "cs2"}
+
 
 class TestPandaScoreClientRateLimiting:
     """Tests for rate limiting behavior."""
+
+    @pytest.mark.asyncio
+    async def test_fetch_matches_maps_cs2_to_csgo_route(self):
+        from src.pandascore_client import PandaScoreClient
+
+        client = PandaScoreClient(api_key="test-key")
+
+        with patch.object(
+            client,
+            "_fetch_matches",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as mock_fetch:
+            await client.fetch_matches("upcoming", game="cs2")
+
+        endpoint = mock_fetch.await_args.args[0]
+        params = mock_fetch.await_args.args[1]
+        assert endpoint == "/csgo/matches/upcoming"
+        assert params["filter[videogame_title]"] == "cs-2"
+
+    @pytest.mark.asyncio
+    async def test_fetch_match_by_id_maps_cs2_to_csgo_route(self):
+        from src.pandascore_client import PandaScoreClient
+
+        client = PandaScoreClient(api_key="test-key")
+
+        with patch.object(
+            client,
+            "_make_request",
+            new_callable=AsyncMock,
+            return_value={},
+        ) as mock_request:
+            await client.fetch_match_by_id(42, game="cs2")
+
+        assert mock_request.await_args.args[0] == "/csgo/matches/42"
 
     @pytest.mark.asyncio
     async def test_rate_limit_tracking(self):


### PR DESCRIPTION
## Summary

This fixes CS2 match ingestion so Counter-Strike matches actually register in MatchPoint again.

Users were seeing blank CS2 results across `/matches`, `/pick`, and the CS2 live messages even when matches existed. The main causes were:

- the PandaScore client was building CS2 requests with the wrong route instead of the legacy `csgo` endpoints
- sync only considered `DEFAULT_GAMES`, so guild-enabled CS2 could still be skipped entirely
- Counter-Strike payload variants were not consistently normalized back to the app's canonical stored slug, `cs2`

## What changed

- map internal `cs2` requests to PandaScore's legacy `csgo` routes in the client
- add the CS2 query filter used for PandaScore match listing requests
- include guild-enabled games when deciding which titles to sync
- keep partial multi-game sync success instead of discarding successful game fetches when one game fails
- normalize Counter-Strike payload slugs and titles back to stored `game == "cs2"`
- add focused regression tests for client route mapping, parser normalization, and guild-enabled-game sync behavior

## Verification

- `flake8 --jobs=1 src tests alembic`
- `python -m pytest tests/test_pandascore.py`

## Notes

- Full `pytest` in this environment is still blocked by the existing Windows temp-path permission problem in `tmp_path`-using tests, but the touched PandaScore path is covered and passing.