### PR TITLE
fix: scope teams by game for sync

### DIFF
--- a/alembic/versions/8f7c6b5a4d3e_scope_team_uniqueness_by_game.py
+++ b/alembic/versions/8f7c6b5a4d3e_scope_team_uniqueness_by_game.py
@@ -44,7 +44,6 @@ def _add_team_game_column() -> None:
             GAME_COLUMN,
             sqlmodel.sql.sqltypes.AutoString(),
             nullable=True,
-            server_default=sa.text("'lol'"),
         ),
     )
 
@@ -53,9 +52,7 @@ def _backfill_team_game() -> None:
     conn = op.get_bind()
     team1_col, team2_col = _match_team_id_columns()
     if team1_col and team2_col:
-        conn.execute(
-            sa.text(
-                f"""
+        conn.execute(sa.text(f"""
                 UPDATE team
                    SET game = COALESCE(
                        (
@@ -76,9 +73,7 @@ def _backfill_team_game() -> None:
                    )
                  WHERE pandascore_id IS NOT NULL
                    AND (game IS NULL OR TRIM(game) = '')
-                """
-            )
-        )
+                """))
     conn.execute(
         sa.text("""
             UPDATE team
@@ -138,9 +133,7 @@ def _restore_global_team_uniqueness() -> None:
     indexes = _index_names(TEAM_TABLE)
     constraints = _unique_constraint_names(TEAM_TABLE)
     with op.batch_alter_table(TEAM_TABLE, recreate="always") as batch_op:
-        _drop_constraint_if_present(
-            batch_op, constraints, "uq_team_name_game"
-        )
+        _drop_constraint_if_present(batch_op, constraints, "uq_team_name_game")
         _drop_constraint_if_present(
             batch_op,
             constraints,

--- a/alembic/versions/8f7c6b5a4d3e_scope_team_uniqueness_by_game.py
+++ b/alembic/versions/8f7c6b5a4d3e_scope_team_uniqueness_by_game.py
@@ -1,0 +1,203 @@
+"""Scope team uniqueness by game.
+
+Revision ID: 8f7c6b5a4d3e
+Revises: c1d2e3f4a5b6
+Create Date: 2026-03-14
+"""
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+
+TEAM_TABLE = "team"
+GAME_COLUMN = "game"
+GAME_DEFAULT = "lol"
+
+# revision identifiers, used by Alembic.
+revision = "8f7c6b5a4d3e"
+down_revision = "c1d2e3f4a5b6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    _add_team_game_column()
+    _backfill_team_game()
+    _rebuild_team_table_for_game_scope()
+
+
+def downgrade():
+    conn = op.get_bind()
+    _assert_no_duplicate_rows(conn, "name")
+    _assert_no_duplicate_rows(conn, "pandascore_id")
+    _restore_global_team_uniqueness()
+
+
+def _add_team_game_column() -> None:
+    inspector = sa.inspect(op.get_bind())
+    columns = {column["name"] for column in inspector.get_columns(TEAM_TABLE)}
+    if GAME_COLUMN in columns:
+        return
+    op.add_column(
+        TEAM_TABLE,
+        sa.Column(
+            GAME_COLUMN,
+            sqlmodel.sql.sqltypes.AutoString(),
+            nullable=True,
+            server_default=sa.text("'lol'"),
+        ),
+    )
+
+
+def _backfill_team_game() -> None:
+    conn = op.get_bind()
+    team1_col, team2_col = _match_team_id_columns()
+    if team1_col and team2_col:
+        conn.execute(
+            sa.text(
+                f"""
+                UPDATE team
+                   SET game = COALESCE(
+                       (
+                           SELECT match.game
+                             FROM match
+                            WHERE match.{team1_col} = team.pandascore_id
+                              AND match.game IS NOT NULL
+                            LIMIT 1
+                       ),
+                       (
+                           SELECT match.game
+                             FROM match
+                            WHERE match.{team2_col} = team.pandascore_id
+                              AND match.game IS NOT NULL
+                            LIMIT 1
+                       ),
+                       game
+                   )
+                 WHERE pandascore_id IS NOT NULL
+                   AND (game IS NULL OR TRIM(game) = '')
+                """
+            )
+        )
+    conn.execute(
+        sa.text("""
+            UPDATE team
+               SET game = :default_game
+             WHERE game IS NULL OR TRIM(game) = ''
+            """),
+        {"default_game": GAME_DEFAULT},
+    )
+
+
+def _match_team_id_columns() -> tuple[str | None, str | None]:
+    inspector = sa.inspect(op.get_bind())
+    columns = {column["name"] for column in inspector.get_columns("match")}
+    return (
+        _preferred_column(columns, "team1_id", "pandascore_team1_id"),
+        _preferred_column(columns, "team2_id", "pandascore_team2_id"),
+    )
+
+
+def _preferred_column(
+    columns: set[str], preferred: str, legacy: str
+) -> str | None:
+    if preferred in columns:
+        return preferred
+    if legacy in columns:
+        return legacy
+    return None
+
+
+def _rebuild_team_table_for_game_scope() -> None:
+    indexes = _index_names(TEAM_TABLE)
+    with op.batch_alter_table(TEAM_TABLE, recreate="always") as batch_op:
+        _drop_index_if_present(batch_op, indexes, "ix_team_name")
+        _drop_index_if_present(batch_op, indexes, "ix_team_pandascore_id")
+        _drop_index_if_present(batch_op, indexes, "ix_team_game")
+        batch_op.alter_column(
+            GAME_COLUMN,
+            existing_type=sqlmodel.sql.sqltypes.AutoString(),
+            nullable=False,
+            server_default=sa.text("'lol'"),
+        )
+        batch_op.create_index("ix_team_game", [GAME_COLUMN], unique=False)
+        batch_op.create_index("ix_team_name", ["name"], unique=False)
+        batch_op.create_index(
+            "ix_team_pandascore_id", ["pandascore_id"], unique=False
+        )
+        batch_op.create_unique_constraint(
+            "uq_team_name_game", ["name", GAME_COLUMN]
+        )
+        batch_op.create_unique_constraint(
+            "uq_team_pandascore_id_game",
+            ["pandascore_id", GAME_COLUMN],
+        )
+
+
+def _restore_global_team_uniqueness() -> None:
+    indexes = _index_names(TEAM_TABLE)
+    constraints = _unique_constraint_names(TEAM_TABLE)
+    with op.batch_alter_table(TEAM_TABLE, recreate="always") as batch_op:
+        _drop_constraint_if_present(
+            batch_op, constraints, "uq_team_name_game"
+        )
+        _drop_constraint_if_present(
+            batch_op,
+            constraints,
+            "uq_team_pandascore_id_game",
+        )
+        _drop_index_if_present(batch_op, indexes, "ix_team_game")
+        _drop_index_if_present(batch_op, indexes, "ix_team_name")
+        _drop_index_if_present(batch_op, indexes, "ix_team_pandascore_id")
+        batch_op.create_index("ix_team_name", ["name"], unique=True)
+        batch_op.create_index(
+            "ix_team_pandascore_id", ["pandascore_id"], unique=True
+        )
+        batch_op.drop_column(GAME_COLUMN)
+
+
+def _index_names(table: str) -> set[str]:
+    inspector = sa.inspect(op.get_bind())
+    return {index["name"] for index in inspector.get_indexes(table)}
+
+
+def _unique_constraint_names(table: str) -> set[str]:
+    inspector = sa.inspect(op.get_bind())
+    return {
+        constraint["name"]
+        for constraint in inspector.get_unique_constraints(table)
+        if constraint["name"]
+    }
+
+
+def _drop_constraint_if_present(
+    batch_op, existing: set[str], name: str
+) -> None:
+    if name in existing:
+        batch_op.drop_constraint(name, type_="unique")
+
+
+def _drop_index_if_present(batch_op, existing: set[str], name: str) -> None:
+    if name in existing:
+        batch_op.drop_index(name)
+
+
+def _assert_no_duplicate_rows(conn, column: str) -> None:
+    value_filter = "IS NOT NULL" if column == "pandascore_id" else "!= ''"
+    stmt = sa.text(f"""
+        SELECT COUNT(1)
+          FROM (
+                SELECT {column}
+                  FROM {TEAM_TABLE}
+                 WHERE {column} {value_filter}
+                 GROUP BY {column}
+                HAVING COUNT(1) > 1
+               ) AS duplicates
+        """)
+    duplicate_count = int(conn.execute(stmt).scalar() or 0)
+    if duplicate_count == 0:
+        return
+    raise RuntimeError(
+        "Cannot downgrade team game scoping while duplicate "
+        f"{column} values exist across games ({duplicate_count} duplicates)."
+    )

--- a/src/crud/contest.py
+++ b/src/crud/contest.py
@@ -79,17 +79,18 @@ async def upsert_contest_by_pandascore(
         return None
 
     try:
-        contest = await get_contest_by_pandascore_ids(
-            session, league_id, serie_id
-        )
+        async with session.begin_nested():
+            contest = await get_contest_by_pandascore_ids(
+                session, league_id, serie_id
+            )
 
-        if contest:
-            _update_contest_from_data(contest, contest_data)
-        else:
-            contest = _create_contest_from_data(contest_data)
+            if contest:
+                _update_contest_from_data(contest, contest_data)
+            else:
+                contest = _create_contest_from_data(contest_data)
 
-        session.add(contest)
-        await session.flush()
+            session.add(contest)
+            await session.flush()
         logger.info("Upserted contest: %s (ID: %s)", contest.name, contest.id)
         return contest
     except Exception:

--- a/src/crud/match.py
+++ b/src/crud/match.py
@@ -50,39 +50,40 @@ async def upsert_match(
         return None, False
 
     try:
-        existing_match = await session.exec(
-            select(Match)
-            .where(Match.leaguepedia_id == leaguepedia_id)
-            .options(selectinload(Match.result))
-        )
-        match = existing_match.first()
-        time_changed = False
+        async with session.begin_nested():
+            existing_match = await session.exec(
+                select(Match)
+                .where(Match.leaguepedia_id == leaguepedia_id)
+                .options(selectinload(Match.result))
+            )
+            match = existing_match.first()
+            time_changed = False
 
-        if match:
-            # Update existing match
-            logger.info("Updating existing match ID: %s", match.id)
-            match.team1 = match_data["team1"]
-            match.team2 = match_data["team2"]
-            match.best_of = match_data.get("best_of")
-            original_time = match.scheduled_time
-            new_time = match_data["scheduled_time"]
-            if original_time != new_time:
-                logger.info(
-                    "Match %s time changed from %s to %s",
-                    match.id,
-                    original_time,
-                    new_time,
-                )
-                time_changed = True
-            match.scheduled_time = new_time
-        else:
-            # Create new match
-            logger.info("Creating new match: %s", match_data)
-            match = Match(**match_data)
-            time_changed = True  # It's a new match, so schedule it
+            if match:
+                # Update existing match
+                logger.info("Updating existing match ID: %s", match.id)
+                match.team1 = match_data["team1"]
+                match.team2 = match_data["team2"]
+                match.best_of = match_data.get("best_of")
+                original_time = match.scheduled_time
+                new_time = match_data["scheduled_time"]
+                if original_time != new_time:
+                    logger.info(
+                        "Match %s time changed from %s to %s",
+                        match.id,
+                        original_time,
+                        new_time,
+                    )
+                    time_changed = True
+                match.scheduled_time = new_time
+            else:
+                # Create new match
+                logger.info("Creating new match: %s", match_data)
+                match = Match(**match_data)
+                time_changed = True  # It's a new match, so schedule it
 
-        session.add(match)
-        await session.flush()  # Flush to get the match.id if it's new
+            session.add(match)
+            await session.flush()  # Flush to get the match.id if it's new
         logger.info("Upserted match ID: %s", match.id)
 
         return match, time_changed
@@ -119,25 +120,26 @@ async def upsert_match_by_pandascore(
         return None, False, False, None
 
     try:
-        result = await session.exec(
-            select(Match)
-            .where(Match.pandascore_id == pandascore_id)
-            .options(selectinload(Match.result))
-        )
-        match = result.first()
-        is_new = False
-        original_time = None
-
-        if match:
-            time_changed, original_time = _update_match_from_data(
-                match, match_data
+        async with session.begin_nested():
+            result = await session.exec(
+                select(Match)
+                .where(Match.pandascore_id == pandascore_id)
+                .options(selectinload(Match.result))
             )
-        else:
-            match, time_changed = _create_match_from_data(match_data)
-            is_new = True
+            match = result.first()
+            is_new = False
+            original_time = None
 
-        session.add(match)
-        await session.flush()
+            if match:
+                time_changed, original_time = _update_match_from_data(
+                    match, match_data
+                )
+            else:
+                match, time_changed = _create_match_from_data(match_data)
+                is_new = True
+
+            session.add(match)
+            await session.flush()
         logger.info(
             "Upserted match ID: %s (PandaScore: %s)", match.id, pandascore_id
         )

--- a/src/crud/sync_utils.py
+++ b/src/crud/sync_utils.py
@@ -39,14 +39,15 @@ async def _upsert_by_leaguepedia(
         return None
 
     try:
-        obj = await _find_existing_by_leaguepedia(
-            session, model, leaguepedia_id
-        )
-        if obj is None:
-            return await _create_new_by_leaguepedia(session, model, data)
-        return await _update_existing_by_leaguepedia(
-            session, obj, data, update_keys
-        )
+        async with session.begin_nested():
+            obj = await _find_existing_by_leaguepedia(
+                session, model, leaguepedia_id
+            )
+            if obj is None:
+                return await _create_new_by_leaguepedia(session, model, data)
+            return await _update_existing_by_leaguepedia(
+                session, obj, data, update_keys
+            )
     except Exception:
         logger.exception(
             "Error upserting %s with data: %s",

--- a/src/crud/team.py
+++ b/src/crud/team.py
@@ -121,9 +121,12 @@ async def _get_team_by_name(
 def _update_team_from_data(team: Team, team_data: dict) -> None:
     """Updates existing team fields from data."""
     logger.info("Updating existing team: %s", team.name)
-    for key in ["name", "acronym", "image_url", "pandascore_id", "game"]:
+    for key in ["name", "acronym", "image_url"]:
         if key in team_data and team_data[key] is not None:
             setattr(team, key, team_data[key])
+    incoming_pandascore_id = team_data.get("pandascore_id")
+    if team.pandascore_id is None and incoming_pandascore_id is not None:
+        team.pandascore_id = incoming_pandascore_id
 
 
 def _create_team_from_data(team_data: dict) -> Team:
@@ -141,7 +144,10 @@ async def get_team_by_pandascore_id(
     Fetch a team by its PandaScore ID.
 
     Parameters:
-        pandascore_id: The PandaScore team ID
+        pandascore_id: The PandaScore team ID.
+        game (Optional[str]): Optional game slug filter. When provided,
+            the query is constrained to teams whose `Team.game` matches
+            the supplied slug.
 
     Returns:
         Optional[Team]: The Team if found, None otherwise

--- a/src/crud/team.py
+++ b/src/crud/team.py
@@ -48,152 +48,80 @@ async def upsert_team_by_pandascore(
             or None if pandascore_id is missing or an error occurred.
     """
     pandascore_id = team_data.get("pandascore_id")
+    game = _resolved_team_game(team_data)
+    name = team_data.get("name")
     if pandascore_id is None:
         logger.error("Missing pandascore_id in team_data")
         return None
+    if not name:
+        logger.error("Missing team name in team_data: %s", team_data)
+        return None
 
     try:
-        team = await _find_team_by_pandascore_or_name(session, team_data)
+        async with session.begin_nested():
+            team = await _find_team_by_pandascore_or_name(session, team_data)
 
-        if team:
-            _update_team_from_data(team, team_data)
-        else:
-            team = _create_team_from_data(team_data)
+            if team:
+                _log_existing_team_match(team, team_data)
+                _update_team_from_data(team, team_data)
+            else:
+                team = _create_team_from_data(team_data)
 
-        session.add(team)
-        await session.flush()
+            session.add(team)
+            await session.flush()
         logger.info("Upserted team: %s (ID: %s)", team.name, team.id)
         return team
     except Exception:
-        logger.exception("Error upserting team with data: %s", team_data)
+        logger.exception(
+            "Error upserting team with game=%s name=%s pandascore_id=%s",
+            game,
+            name,
+            pandascore_id,
+        )
         return None
 
 
 async def _find_team_by_pandascore_or_name(
-    session: AsyncSession,
-    team_data: dict,
-    allow_name_fallback: bool = False,
+    session: AsyncSession, team_data: dict
 ) -> Optional[Team]:
-    """Finds a team by PandaScore ID or optionally by name.
-
-    Lookup strategy:
-    1. If `pandascore_id` is present, return the team matching that ID.
-    2. If not found and `allow_name_fallback` is True, attempt a name-based
-       lookup but only if additional validation attributes (such as
-       `acronym` or `region`) are provided. When falling back, require at
-       least one validation field to match the candidate before returning
-       it. This avoids silently linking wrong teams by name alone.
-
-    Parameters:
-        session: AsyncSession to use for DB queries.
-        team_data: Mapping with incoming team fields (may include
-            `pandascore_id`, `name`, `acronym`, `region`).
-        allow_name_fallback: If True, permit name-based fallback subject to
-            validation (default False).
-
-    Returns:
-        Optional[Team]: Matched `Team` or `None` if no safe match was found.
-    """
+    """Find a team by PandaScore ID or exact same-game name."""
+    game = _resolved_team_game(team_data)
     pandascore_id = team_data.get("pandascore_id")
     if pandascore_id is not None:
-        team = await _get_team_by_pandascore(session, pandascore_id)
+        team = await _get_team_by_pandascore(session, pandascore_id, game)
         if team:
             return team
-
-    # Short-circuit when name fallback isn't allowed
-    if not allow_name_fallback:
-        return None
 
     name = team_data.get("name")
     if not name:
         return None
-
-    provided_acronym = team_data.get("acronym")
-    provided_region = team_data.get("region")
-    if not provided_acronym and not provided_region:
-        logger.debug(
-            "Name fallback disabled; no validation fields for '%s'",
-            name,
-        )
-        return None
-
-    validation = {"acronym": provided_acronym, "region": provided_region}
-    return await _find_valid_candidate_by_name(
-        session, name, validation, team_data.get("pandascore_id")
-    )
+    return await _get_team_by_name(session, name, game)
 
 
 async def _get_team_by_pandascore(
-    session: AsyncSession, pandascore_id: int
+    session: AsyncSession, pandascore_id: int, game: str
 ) -> Optional[Team]:
     result = await session.exec(
-        select(Team).where(Team.pandascore_id == pandascore_id)
+        select(Team).where(
+            Team.pandascore_id == pandascore_id,
+            Team.game == game,
+        )
     )
     return result.first()
 
 
-async def _get_candidates_by_name(
-    session: AsyncSession, name: str, acronym: Optional[str] = None
-) -> list[Team]:
-    query = select(Team).where(Team.name == name)
-    if acronym is not None:
-        query = query.where(Team.acronym == acronym)
-    result = await session.exec(query)
-    return result.all()
-
-
-def _candidate_matches_validation(
-    cand: Team, provided_acronym: Optional[str], provided_region: Optional[str]
-) -> bool:
-    if (
-        provided_acronym is not None
-        and getattr(cand, "acronym", None) != provided_acronym
-    ):
-        return False
-    if (
-        provided_region is not None
-        and getattr(cand, "region", None) != provided_region
-    ):
-        return False
-    return True
-
-
-async def _find_valid_candidate_by_name(
-    session: AsyncSession,
-    name: str,
-    validation: dict[str, Optional[str]] | None = None,
-    incoming_pandascore_id: Optional[int] = None,
+async def _get_team_by_name(
+    session: AsyncSession, name: str, game: str
 ) -> Optional[Team]:
-    """Return the first candidate matching validation rules, or None.
-
-    `validation` may contain keys like `acronym` and `region` used to
-    validate candidate matches.
-    """
-    provided_acronym = (
-        None if validation is None else validation.get("acronym")
-    )
-    provided_region = None if validation is None else validation.get("region")
-
-    candidates = await _get_candidates_by_name(session, name, provided_acronym)
-    for cand in candidates:
-        if _candidate_matches_validation(
-            cand, provided_acronym, provided_region
-        ):
-            logger.warning(
-                "Name fallback matched id %s for incoming id %s (name=%s)",
-                cand.id,
-                incoming_pandascore_id,
-                name,
-            )
-            return cand
-    logger.debug("No validated name-fallback for %s", name)
-    return None
+    query = select(Team).where(Team.name == name, Team.game == game)
+    result = await session.exec(query)
+    return result.first()
 
 
 def _update_team_from_data(team: Team, team_data: dict) -> None:
     """Updates existing team fields from data."""
     logger.info("Updating existing team: %s", team.name)
-    for key in ["name", "acronym", "image_url", "pandascore_id"]:
+    for key in ["name", "acronym", "image_url", "pandascore_id", "game"]:
         if key in team_data and team_data[key] is not None:
             setattr(team, key, team_data[key])
 
@@ -205,7 +133,9 @@ def _create_team_from_data(team_data: dict) -> Team:
 
 
 async def get_team_by_pandascore_id(
-    session: AsyncSession, pandascore_id: int
+    session: AsyncSession,
+    pandascore_id: int,
+    game: Optional[str] = None,
 ) -> Optional[Team]:
     """
     Fetch a team by its PandaScore ID.
@@ -216,7 +146,28 @@ async def get_team_by_pandascore_id(
     Returns:
         Optional[Team]: The Team if found, None otherwise
     """
-    result = await session.exec(
-        select(Team).where(Team.pandascore_id == pandascore_id)
-    )
+    stmt = select(Team).where(Team.pandascore_id == pandascore_id)
+    if game:
+        stmt = stmt.where(Team.game == game)
+    result = await session.exec(stmt)
     return result.first()
+
+
+def _resolved_team_game(team_data: dict) -> str:
+    return str(team_data.get("game") or "lol").strip().lower() or "lol"
+
+
+def _log_existing_team_match(team: Team, team_data: dict) -> None:
+    incoming_id = team_data.get("pandascore_id")
+    incoming_game = _resolved_team_game(team_data)
+    if team.pandascore_id == incoming_id:
+        return
+    logger.warning(
+        "Matched existing team row id=%s for game=%s name=%s "
+        "(existing pandascore_id=%s, incoming pandascore_id=%s)",
+        team.id,
+        incoming_game,
+        team.name,
+        team.pandascore_id,
+        incoming_id,
+    )

--- a/src/match_result_utils.py
+++ b/src/match_result_utils.py
@@ -229,16 +229,20 @@ async def fetch_teams(session, match: Match):
             function does not raise on missing teams; callers should
             handle `None` values appropriately.
     """
-    if match.team1_id:
-        t1_stmt = select(Team).where(Team.pandascore_id == match.team1_id)
-    else:
-        t1_stmt = select(Team).where(Team.name == match.team1)
-
-    if match.team2_id:
-        t2_stmt = select(Team).where(Team.pandascore_id == match.team2_id)
-    else:
-        t2_stmt = select(Team).where(Team.name == match.team2)
+    t1_stmt = _build_team_lookup_stmt(match, match.team1_id, match.team1)
+    t2_stmt = _build_team_lookup_stmt(match, match.team2_id, match.team2)
 
     team1 = (await session.exec(t1_stmt)).first()
     team2 = (await session.exec(t2_stmt)).first()
     return team1, team2
+
+
+def _build_team_lookup_stmt(match: Match, team_id, team_name):
+    stmt = select(Team).where(Team.game == _match_game(match))
+    if team_id:
+        return stmt.where(Team.pandascore_id == team_id)
+    return stmt.where(Team.name == team_name)
+
+
+def _match_game(match: Match) -> str:
+    return getattr(match, "game", None) or "lol"

--- a/src/match_result_utils.py
+++ b/src/match_result_utils.py
@@ -238,11 +238,18 @@ async def fetch_teams(session, match: Match):
 
 
 def _build_team_lookup_stmt(match: Match, team_id, team_name):
-    stmt = select(Team).where(Team.game == _match_game(match))
+    stmt = select(Team)
+    game = _match_game(match)
+    if game is not None:
+        stmt = stmt.where(Team.game == game)
     if team_id:
         return stmt.where(Team.pandascore_id == team_id)
     return stmt.where(Team.name == team_name)
 
 
-def _match_game(match: Match) -> str:
-    return getattr(match, "game", None) or "lol"
+def _match_game(match: Match) -> Optional[str]:
+    game = getattr(match, "game", None)
+    if game is None:
+        return None
+    normalized = game.strip().lower()
+    return normalized or None

--- a/src/models.py
+++ b/src/models.py
@@ -47,10 +47,19 @@ class User(SQLModel, table=True):
 
 
 class Team(SQLModel, table=True):
+    __table_args__ = (
+        sa.UniqueConstraint("name", "game", name="uq_team_name_game"),
+        sa.UniqueConstraint(
+            "pandascore_id",
+            "game",
+            name="uq_team_pandascore_id_game",
+        ),
+    )
     id: Optional[int] = Field(default=None, primary_key=True)
-    name: str = Field(index=True, unique=True)
+    name: str = Field(index=True)
+    game: str = Field(default="lol", index=True)
     leaguepedia_id: Optional[str] = Field(default=None, index=True)
-    pandascore_id: Optional[int] = Field(default=None, index=True, unique=True)
+    pandascore_id: Optional[int] = Field(default=None, index=True)
     image_url: Optional[str] = None
     acronym: Optional[str] = None
     roster: Optional[str] = None  # Storing as JSON string

--- a/src/notification_batcher.py
+++ b/src/notification_batcher.py
@@ -3,7 +3,15 @@ import logging
 from collections import defaultdict
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
-from typing import Any, AsyncGenerator, Callable, List, Optional, Tuple
+from typing import (
+    Any,
+    AsyncGenerator,
+    Callable,
+    List,
+    Optional,
+    Set,
+    Tuple,
+)
 
 import discord
 from sqlalchemy.orm import selectinload
@@ -370,7 +378,9 @@ async def _bulk_fetch_matches(session, match_ids: List[int]) -> List[Match]:
 async def _bulk_fetch_teams(session, matches: List[Match]) -> dict:
     games, ids, names = _collect_team_keys(matches)
 
-    if not games or (not ids and not names):
+    if not games:
+        return {}
+    if not ids and not names:
         return {}
 
     conditions = []
@@ -392,7 +402,9 @@ async def _bulk_fetch_teams(session, matches: List[Match]) -> dict:
     return {"id": by_id, "name": by_name}
 
 
-def _collect_team_keys(matches: List[Match]):
+def _collect_team_keys(
+    matches: List[Match],
+) -> Tuple[Set[str], Set[int], Set[str]]:
     games = set()
     ids = set()
     names = set()

--- a/src/notification_batcher.py
+++ b/src/notification_batcher.py
@@ -368,9 +368,9 @@ async def _bulk_fetch_matches(session, match_ids: List[int]) -> List[Match]:
 
 
 async def _bulk_fetch_teams(session, matches: List[Match]) -> dict:
-    ids, names = _collect_team_ids_and_names(matches)
+    games, ids, names = _collect_team_keys(matches)
 
-    if not ids and not names:
+    if not games or (not ids and not names):
         return {}
 
     conditions = []
@@ -379,19 +379,25 @@ async def _bulk_fetch_teams(session, matches: List[Match]) -> dict:
     if names:
         conditions.append(Team.name.in_(names))
 
-    stmt = select(Team).where(or_(*conditions))
+    stmt = select(Team).where(Team.game.in_(games), or_(*conditions))
     teams = (await session.exec(stmt)).all()
 
-    # Map by ID and Name
-    by_id = {t.pandascore_id: t for t in teams if t.pandascore_id}
-    by_name = {t.name: t for t in teams}
+    # Map by (game, ID) and (game, name)
+    by_id = {
+        (t.game, t.pandascore_id): t
+        for t in teams
+        if t.pandascore_id is not None
+    }
+    by_name = {(t.game, t.name): t for t in teams}
     return {"id": by_id, "name": by_name}
 
 
-def _collect_team_ids_and_names(matches: List[Match]):
+def _collect_team_keys(matches: List[Match]):
+    games = set()
     ids = set()
     names = set()
     for m in matches:
+        games.add(_match_game(m))
         if m.team1_id:
             ids.add(m.team1_id)
         else:
@@ -401,7 +407,7 @@ def _collect_team_ids_and_names(matches: List[Match]):
             ids.add(m.team2_id)
         else:
             names.add(m.team2)
-    return ids, names
+    return games, ids, names
 
 
 def _resolve_teams(
@@ -409,18 +415,23 @@ def _resolve_teams(
 ) -> Tuple[Optional[Team], Optional[Team]]:
     by_id = teams_map.get("id", {})
     by_name = teams_map.get("name", {})
+    game = _match_game(match)
 
     t1 = (
-        by_id.get(match.team1_id)
+        by_id.get((game, match.team1_id))
         if match.team1_id
-        else by_name.get(match.team1)
+        else by_name.get((game, match.team1))
     )
     t2 = (
-        by_id.get(match.team2_id)
+        by_id.get((game, match.team2_id))
         if match.team2_id
-        else by_name.get(match.team2)
+        else by_name.get((game, match.team2))
     )
     return t1, t2
+
+
+def _match_game(match: Match) -> str:
+    return getattr(match, "game", None) or "lol"
 
 
 async def _bulk_fetch_pick_stats(session, match_ids: List[int]) -> dict:

--- a/src/pandascore_processing.py
+++ b/src/pandascore_processing.py
@@ -37,13 +37,16 @@ class PandaScoreSyncContext:
 
 
 async def _process_teams_from_match(
-    match_data: Dict[str, Any], ctx: PandaScoreSyncContext
+    match_data: Dict[str, Any],
+    game: str,
+    ctx: PandaScoreSyncContext,
 ) -> None:
     opponents = match_data.get("opponents", [])
 
     for opponent in opponents:
         team_data = ctx.parser.extract_team_data(opponent)
         if team_data and team_data.get("pandascore_id"):
+            team_data["game"] = game
             team = await upsert_team_by_pandascore(ctx.db_session, team_data)
             if team:
                 ctx.summary["teams"] += 1
@@ -87,11 +90,10 @@ async def _process_single_match(
     if not contest:
         return None
 
-    await _process_teams_from_match(match_data, ctx)
-
     match_info = ctx.parser.extract_match_data(match_data, contest.id)
     if not match_info:
         return None
+    await _process_teams_from_match(match_data, match_info["game"], ctx)
 
     match, is_new, time_changed, old_time = await upsert_match_by_pandascore(
         ctx.db_session, match_info
@@ -149,10 +151,11 @@ async def _detect_match_result(
     )
 
     try:
-        result = await save_result_and_update_picks(
-            ctx.db_session, match, winner_name, score_str
-        )
-        await ctx.db_session.flush()
+        async with ctx.db_session.begin_nested():
+            result = await save_result_and_update_picks(
+                ctx.db_session, match, winner_name, score_str
+            )
+            await ctx.db_session.flush()
         ctx.notifications.append((match.id, result.id))
     except Exception:
         logger.exception("Failed to save result for match %s", match.id)

--- a/tests/test_team_game_scope.py
+++ b/tests/test_team_game_scope.py
@@ -1,0 +1,171 @@
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import uuid4
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel, select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from src.crud.contest import upsert_contest_by_pandascore
+from src.crud.team import upsert_team_by_pandascore
+from src.match_result_utils import fetch_teams
+from src.models import Match, Team
+from src.notification_batcher import _bulk_fetch_teams, _resolve_teams
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    db_path = Path.cwd() / f"test-team-game-scope-{uuid4().hex}.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}", echo=False)
+    async_session = sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
+
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    try:
+        async with async_session() as session:
+            yield session
+    finally:
+        await engine.dispose()
+        if db_path.exists():
+            db_path.unlink()
+
+
+@pytest.mark.asyncio
+async def test_upsert_team_by_pandascore_allows_same_name_across_games(
+    db_session,
+):
+    db_session.add(Team(name="Misa Esports", pandascore_id=1, game="lol"))
+    await db_session.commit()
+
+    team = await upsert_team_by_pandascore(
+        db_session,
+        {
+            "name": "Misa Esports",
+            "pandascore_id": 137075,
+            "acronym": "MISA",
+            "game": "cs2",
+        },
+    )
+    await db_session.commit()
+
+    teams = (
+        await db_session.exec(select(Team).where(Team.name == "Misa Esports"))
+    ).all()
+
+    assert team is not None
+    assert {(row.game, row.pandascore_id) for row in teams} == {
+        ("lol", 1),
+        ("cs2", 137075),
+    }
+
+
+@pytest.mark.asyncio
+async def test_upsert_team_by_pandascore_updates_same_game_name_match(
+    db_session,
+):
+    db_session.add(
+        Team(
+            name="Misa Esports",
+            pandascore_id=None,
+            acronym="OLD",
+            game="cs2",
+        )
+    )
+    await db_session.commit()
+
+    team = await upsert_team_by_pandascore(
+        db_session,
+        {
+            "name": "Misa Esports",
+            "pandascore_id": 137075,
+            "acronym": "MISA",
+            "game": "cs2",
+        },
+    )
+    await db_session.commit()
+
+    teams = (
+        await db_session.exec(
+            select(Team).where(
+                Team.name == "Misa Esports",
+                Team.game == "cs2",
+            )
+        )
+    ).all()
+
+    assert team is not None
+    assert len(teams) == 1
+    assert teams[0].pandascore_id == 137075
+    assert teams[0].acronym == "MISA"
+
+
+@pytest.mark.asyncio
+async def test_team_upsert_failure_does_not_poison_session(db_session):
+    with patch.object(
+        db_session,
+        "flush",
+        new=AsyncMock(side_effect=[IntegrityError("dup", None, None), None]),
+    ):
+        team = await upsert_team_by_pandascore(
+            db_session,
+            {
+                "name": "Misa Esports",
+                "pandascore_id": 137075,
+                "acronym": "MISA",
+                "game": "cs2",
+            },
+        )
+        contest = await upsert_contest_by_pandascore(
+            db_session,
+            {
+                "pandascore_league_id": 5501,
+                "pandascore_serie_id": 10273,
+                "name": "BetBoom Storm Season 1 2026",
+                "start_date": datetime.now(timezone.utc),
+                "end_date": datetime.now(timezone.utc),
+            },
+        )
+
+    assert team is None
+    assert contest is not None
+    assert contest.name == "BetBoom Storm Season 1 2026"
+
+
+@pytest.mark.asyncio
+async def test_game_scoped_team_lookups_return_matching_rows(db_session):
+    lol_team = Team(name="Misa Esports", pandascore_id=1, game="lol")
+    cs2_team = Team(name="Misa Esports", pandascore_id=2, game="cs2")
+    other_team = Team(name="Other", pandascore_id=3, game="cs2")
+    db_session.add(lol_team)
+    db_session.add(cs2_team)
+    db_session.add(other_team)
+    await db_session.commit()
+
+    cs2_match = Match(
+        contest_id=1,
+        team1="Misa Esports",
+        team2="Other",
+        team1_id=2,
+        team2_id=3,
+        game="cs2",
+        scheduled_time=datetime.now(timezone.utc),
+    )
+    teams = await fetch_teams(db_session, cs2_match)
+    teams_map = await _bulk_fetch_teams(db_session, [cs2_match])
+    resolved = _resolve_teams(cs2_match, teams_map)
+
+    assert teams[0] is not None
+    assert teams[0].game == "cs2"
+    assert teams[0].pandascore_id == 2
+    assert resolved[0] is not None
+    assert resolved[0].game == "cs2"
+    assert resolved[1] is not None
+    assert resolved[1].name == "Other"


### PR DESCRIPTION
## Summary

- scope PandaScore team rows by game so LoL and CS2 teams with the same name no longer collide
- make PandaScore sync writes rollback-safe so a failed team flush does not poison the shared session
- update runtime team lookups and add regression coverage for the new game-scoped behavior

## Testing

- python -m pytest tests/test_team_game_scope.py tests/test_pandascore.py tests/test_notification_batcher.py
- python -m pytest tests/test_match_result_utils.py tests/test_live_messages.py
- python -m flake8 --jobs=1 src tests alembic
- python -m alembic upgrade head (with a temporary sqlite DATABASE_URL)