### PR TITLE
[codex] restore lol live message filtering

### DIFF
--- a/src/commands/matches.py
+++ b/src/commands/matches.py
@@ -32,6 +32,7 @@ STATUS_MAP = {
     "canceled": "❌ Canceled",
     "postponed": "🕒 Postponed",
 }
+LIVE_STATUSES = ("running", "live", "in_progress")
 
 
 def _format_match_value(m: Match) -> str:
@@ -50,7 +51,7 @@ def _format_match_value(m: Match) -> str:
     if m.result:
         score_str = f" ({m.result.score})" if m.result.score else ""
         value += f"\n**Result:** **{m.result.winner}** won{score_str}"
-    elif m.status == "running" and m.last_announced_score:
+    elif m.status in LIVE_STATUSES and m.last_announced_score:
         value += f"\n**Current Score:** {m.last_announced_score}"
     return value
 

--- a/src/commands/matches.py
+++ b/src/commands/matches.py
@@ -13,6 +13,7 @@ from src.db import get_session
 from src.models import Contest, Match
 from src import crud
 from src.auth import is_admin
+from src.parsers.game_slug import game_display_name
 
 logger = logging.getLogger("esports-bot.commands.matches")
 
@@ -24,7 +25,10 @@ matches_group = app_commands.Group(
 STATUS_MAP = {
     "finished": "✅ Finished",
     "running": "🔴 Live",
+    "live": "🔴 Live",
+    "in_progress": "🔴 Live",
     "not_started": "⏳ Upcoming",
+    "scheduled": "⏳ Upcoming",
     "canceled": "❌ Canceled",
     "postponed": "🕒 Postponed",
 }
@@ -36,6 +40,7 @@ def _format_match_value(m: Match) -> str:
     )
     time_str = m.scheduled_time.strftime("%H:%M UTC")
     value = (
+        f"**Game:** {game_display_name(getattr(m, 'game', None))}\n"
         f"**Status:** {status_label}\n"
         f"**Time:** {time_str}\n"
         f"**Contest:** {m.contest.name if m.contest else 'Unknown'}"

--- a/src/live_messages.py
+++ b/src/live_messages.py
@@ -18,6 +18,7 @@ from src.crud import (
 from src.db import get_async_session
 from src.models import Match, Result
 from src.parsers.factory import get_supported_game_slugs
+from src.parsers.game_slug import game_display_name, game_query_slugs
 
 logger = logging.getLogger(__name__)
 
@@ -26,11 +27,15 @@ UPCOMING_MATCH_LIMIT = 10
 RUNNING_MATCH_LIMIT = 25
 RESULTS_MATCH_LIMIT = 10
 RUNNING_MATCH_STALE_HOURS = 24
-NON_UPCOMING_STATUSES = ("running", "finished", "canceled", "postponed")
-GAME_DISPLAY_NAMES = {
-    "lol": "LoL",
-    "cs2": "CS2",
-}
+NON_UPCOMING_STATUSES = (
+    "running",
+    "live",
+    "in_progress",
+    "finished",
+    "canceled",
+    "postponed",
+)
+LIVE_MATCH_STATUSES = ("running", "live", "in_progress")
 
 
 @dataclass(frozen=True)
@@ -349,11 +354,12 @@ async def _build_live_message_embed(
 
 async def _fetch_upcoming_matches(game: str) -> list[Match]:
     now = datetime.now(timezone.utc)
+    game_slugs = game_query_slugs(game)
     async with get_async_session() as session:
         stmt = (
             select(Match)
             .options(selectinload(Match.contest))
-            .where(Match.game == game)
+            .where(Match.game.in_(game_slugs))
             .where(Match.scheduled_time >= now)
             .where(Match.status.notin_(NON_UPCOMING_STATUSES))
             .order_by(Match.scheduled_time, Match.id)
@@ -366,13 +372,14 @@ async def _fetch_running_matches(game: str) -> list[Match]:
     cutoff = datetime.now(timezone.utc) - timedelta(
         hours=RUNNING_MATCH_STALE_HOURS
     )
+    game_slugs = game_query_slugs(game)
     async with get_async_session() as session:
         stmt = (
             select(Match)
             .options(selectinload(Match.contest))
             .outerjoin(Result, Result.match_id == Match.id)
-            .where(Match.game == game)
-            .where(Match.status == "running")
+            .where(Match.game.in_(game_slugs))
+            .where(Match.status.in_(LIVE_MATCH_STATUSES))
             .where(Match.scheduled_time >= cutoff)
             .where(Result.id.is_(None))
             .order_by(Match.scheduled_time, Match.id)
@@ -382,12 +389,13 @@ async def _fetch_running_matches(game: str) -> list[Match]:
 
 
 async def _fetch_recent_results(game: str) -> list[tuple[Match, Result]]:
+    game_slugs = game_query_slugs(game)
     async with get_async_session() as session:
         stmt = (
             select(Match, Result)
             .join(Result, Result.match_id == Match.id)
             .options(selectinload(Match.contest))
-            .where(Match.game == game)
+            .where(Match.game.in_(game_slugs))
             .order_by(Match.scheduled_time.desc(), Match.id.desc())
             .limit(RESULTS_MATCH_LIMIT)
         )
@@ -508,4 +516,4 @@ def _best_of_suffix(match: Match) -> str:
 
 
 def _game_display_name(game: str) -> str:
-    return GAME_DISPLAY_NAMES.get(game, game.upper())
+    return game_display_name(game)

--- a/src/pandascore_sync.py
+++ b/src/pandascore_sync.py
@@ -37,9 +37,10 @@ from src.pandascore_utils import (
     safe_schedule,
 )
 from src.parsers.factory import get_parser, get_supported_game_slugs
-from src.parsers.game_slug import normalize_game_slug
+from src.parsers.game_slug import game_query_slugs, normalize_game_slug
 
 logger = logging.getLogger(__name__)
+RUNNING_MATCH_STATUSES = ("running", "live", "in_progress")
 
 
 def _normalize_enabled_game(
@@ -281,11 +282,13 @@ async def _fetch_matches_for_sync(
 
 
 async def _reconcile_finished_matches_for_game(game_slug: str) -> None:
+    normalized_game = normalize_game_slug(game_slug) or game_slug
+    game_slugs = game_query_slugs(normalized_game)
     async with get_async_session() as db_session:
         stmt = (
             select(Match)
-            .where(Match.game == game_slug)
-            .where(Match.status == "running")
+            .where(Match.game.in_(game_slugs))
+            .where(Match.status.in_(RUNNING_MATCH_STATUSES))
         )
         running_matches = list((await db_session.exec(stmt)).all())
 
@@ -294,10 +297,14 @@ async def _reconcile_finished_matches_for_game(game_slug: str) -> None:
         if not pandascore_id:
             continue
 
-        match_data = await _fetch_pandascore_match(pandascore_id, game_slug)
+        match_data = await _fetch_pandascore_match(
+            pandascore_id, normalized_game
+        )
         if not match_data:
             continue
-        await fetch_and_update_match_result(pandascore_id, game_slug=game_slug)
+        await fetch_and_update_match_result(
+            pandascore_id, game_slug=normalized_game
+        )
 
 
 async def _process_matches_and_commit(

--- a/src/pandascore_sync.py
+++ b/src/pandascore_sync.py
@@ -36,8 +36,8 @@ from src.pandascore_utils import (
     safe_notify,
     safe_schedule,
 )
-from src.parsers.cs2 import normalize_counter_strike_slug
 from src.parsers.factory import get_parser, get_supported_game_slugs
+from src.parsers.game_slug import normalize_game_slug
 
 logger = logging.getLogger(__name__)
 
@@ -433,9 +433,10 @@ async def sync_running_matches() -> Dict[str, Any]:
 
 def _match_data_game(match_data: Dict[str, Any]) -> Optional[str]:
     videogame = match_data.get("videogame") or {}
-    raw_slug = (videogame.get("slug") or "").lower()
-    title = str(match_data.get("videogame_title") or "").lower()
-    return normalize_counter_strike_slug(raw_slug, title) or raw_slug or None
+    return normalize_game_slug(
+        videogame.get("slug"),
+        match_data.get("videogame_title"),
+    )
 
 
 def _default_sync_game() -> str:
@@ -450,7 +451,9 @@ def _default_sync_game() -> str:
 
 def _resolve_match_game(match, match_data: Dict[str, Any]) -> str:
     if getattr(match, "game", None):
-        return match.game
+        normalized = normalize_game_slug(match.game)
+        if normalized:
+            return normalized
 
     resolved_game = _match_data_game(match_data)
     if resolved_game:

--- a/src/parsers/cs2.py
+++ b/src/parsers/cs2.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from typing import Any, Optional
 
 from src.parsers.base import PandaScoreParser
+from src.parsers.game_slug import normalize_game_slug
 
 logger = logging.getLogger(__name__)
 
@@ -42,9 +43,13 @@ def normalize_counter_strike_slug(
 
 def _match_game_slug(match_data: dict[str, Any]) -> str:
     videogame = match_data.get("videogame") or {}
-    raw_slug = (videogame.get("slug") or "").lower()
-    title = str(match_data.get("videogame_title") or "").lower()
-    return normalize_counter_strike_slug(raw_slug, title) or raw_slug or "cs2"
+    return (
+        normalize_game_slug(
+            videogame.get("slug"),
+            match_data.get("videogame_title"),
+        )
+        or "cs2"
+    )
 
 
 class CS2Parser(PandaScoreParser):

--- a/src/parsers/game_slug.py
+++ b/src/parsers/game_slug.py
@@ -1,0 +1,43 @@
+from typing import Optional
+
+
+def normalize_game_slug(
+    slug: Optional[str],
+    title: Optional[str] = None,
+) -> Optional[str]:
+    raw_slug = (slug or "").strip().lower()
+    raw_title = (title or "").strip().lower()
+
+    if raw_slug in {"lol", "league-of-legends", "leagueoflegends"}:
+        return "lol"
+
+    if raw_slug in {"cs2", "csgo", "counterstrike", "counter-strike"}:
+        return "cs2"
+
+    if "league of legends" in raw_title:
+        return "lol"
+
+    if "counter-strike 2" in raw_title or raw_title == "cs2":
+        return "cs2"
+
+    return raw_slug or None
+
+
+def game_query_slugs(game: str) -> tuple[str, ...]:
+    normalized = normalize_game_slug(game) or game.strip().lower()
+    if normalized == "lol":
+        return ("lol", "league-of-legends", "leagueoflegends")
+    if normalized == "cs2":
+        return ("cs2", "csgo", "counterstrike", "counter-strike")
+    return (normalized,)
+
+
+def game_display_name(game: Optional[str]) -> str:
+    normalized = normalize_game_slug(game)
+    if normalized == "lol":
+        return "LoL"
+    if normalized == "cs2":
+        return "CS2"
+    if not game:
+        return "Unknown"
+    return game.upper()

--- a/src/parsers/game_slug.py
+++ b/src/parsers/game_slug.py
@@ -1,6 +1,22 @@
 from typing import Optional
 
 
+def _normalize_lol_slug(raw_slug: str, raw_title: str) -> Optional[str]:
+    if raw_slug in {"lol", "league-of-legends", "leagueoflegends"}:
+        return "lol"
+    if "league of legends" in raw_title:
+        return "lol"
+    return None
+
+
+def _normalize_cs2_slug(raw_slug: str, raw_title: str) -> Optional[str]:
+    if raw_slug in {"cs2", "csgo", "counterstrike", "counter-strike"}:
+        return "cs2"
+    if "counter-strike 2" in raw_title or raw_title == "cs2":
+        return "cs2"
+    return None
+
+
 def normalize_game_slug(
     slug: Optional[str],
     title: Optional[str] = None,
@@ -8,17 +24,13 @@ def normalize_game_slug(
     raw_slug = (slug or "").strip().lower()
     raw_title = (title or "").strip().lower()
 
-    if raw_slug in {"lol", "league-of-legends", "leagueoflegends"}:
-        return "lol"
+    normalized_lol = _normalize_lol_slug(raw_slug, raw_title)
+    if normalized_lol:
+        return normalized_lol
 
-    if raw_slug in {"cs2", "csgo", "counterstrike", "counter-strike"}:
-        return "cs2"
-
-    if "league of legends" in raw_title:
-        return "lol"
-
-    if "counter-strike 2" in raw_title or raw_title == "cs2":
-        return "cs2"
+    normalized_cs2 = _normalize_cs2_slug(raw_slug, raw_title)
+    if normalized_cs2:
+        return normalized_cs2
 
     return raw_slug or None
 

--- a/src/parsers/lol.py
+++ b/src/parsers/lol.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from typing import Optional, Dict, Any, Tuple
 
 from src.parsers.base import PandaScoreParser
+from src.parsers.game_slug import normalize_game_slug
 
 logger = logging.getLogger(__name__)
 
@@ -27,13 +28,13 @@ def _team_display_name(team_info: Dict[str, Any]) -> str:
 
 def _match_game_slug(match_data: Dict[str, Any]) -> str:
     videogame = match_data.get("videogame") or {}
-    raw_slug = (videogame.get("slug") or "").lower()
-    title = str(match_data.get("videogame_title") or "").lower()
-    if raw_slug in {"counterstrike", "counter-strike", "cs2"}:
-        return "cs2"
-    if "counter-strike 2" in title or title == "cs2":
-        return "cs2"
-    return raw_slug or "lol"
+    return (
+        normalize_game_slug(
+            videogame.get("slug"),
+            match_data.get("videogame_title"),
+        )
+        or "lol"
+    )
 
 
 class LoLParser(PandaScoreParser):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,11 @@
 import sys
 import site
 from unittest.mock import AsyncMock, MagicMock
+from typing import Any
 
 import discord
 import pytest
+from sqlmodel import Session
 
 # Insert site-packages directories at the front of sys.path if available.
 site_packages = [p for p in site.getsitepackages() if p not in sys.path]
@@ -25,3 +27,35 @@ def mocked_interaction():
     interaction.response = AsyncMock()
     interaction.followup = AsyncMock()
     return interaction
+
+
+class _ResultWrapper:
+    def __init__(self, rows: list[Any]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[Any]:
+        return self._rows
+
+
+class _AsyncSession:
+    def __init__(self, engine: Any) -> None:
+        self._engine = engine
+
+    async def exec(self, stmt: Any) -> _ResultWrapper:
+        with Session(self._engine) as session:
+            return _ResultWrapper(list(session.exec(stmt).all()))
+
+    async def __aenter__(self) -> "_AsyncSession":
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+        _ = (exc_type, exc, tb)
+        return False
+
+
+@pytest.fixture
+def async_session_for_engine():
+    def factory(engine: Any) -> _AsyncSession:
+        return _AsyncSession(engine)
+
+    return factory

--- a/tests/test_live_messages.py
+++ b/tests/test_live_messages.py
@@ -28,25 +28,6 @@ class _MatchQueryCase:
     matches_to_create: list[Match]
 
 
-def _build_scope_case(
-    *,
-    guild_id: int,
-    channel_id: int,
-    message_id: int,
-    scope: str,
-    embed_title: str,
-    has_live_record: bool = False,
-) -> _RefreshScopeCase:
-    return _RefreshScopeCase(
-        guild_id=guild_id,
-        channel_id=channel_id,
-        message_id=message_id,
-        scope=scope,
-        embed_title=embed_title,
-        has_live_record=has_live_record,
-    )
-
-
 async def _assert_refresh_scope(case: _RefreshScopeCase) -> None:
     guild = MagicMock()
     guild.id = case.guild_id
@@ -116,30 +97,28 @@ async def _assert_refresh_scope(case: _RefreshScopeCase) -> None:
 
 
 @pytest.mark.asyncio
-async def test_refresh_scope_creates_missing_live_message():
-    await _assert_refresh_scope(
-        _build_scope_case(
+@pytest.mark.parametrize(
+    "case",
+    [
+        _RefreshScopeCase(
             guild_id=111,
             channel_id=222,
             message_id=333,
             scope="upcoming",
             embed_title="Upcoming",
-        )
-    )
-
-
-@pytest.mark.asyncio
-async def test_refresh_scope_edits_existing_live_message():
-    await _assert_refresh_scope(
-        _build_scope_case(
+        ),
+        _RefreshScopeCase(
             guild_id=222,
             channel_id=444,
             message_id=555,
             scope="running",
             embed_title="Running",
             has_live_record=True,
-        )
-    )
+        ),
+    ],
+)
+async def test_refresh_scope_behaviors(case):
+    await _assert_refresh_scope(case)
 
 
 def test_build_running_embed_keeps_empty_state_message():
@@ -252,11 +231,9 @@ async def _assert_match_query_ids(
 
 
 @pytest.mark.asyncio
-async def test_fetch_upcoming_matches_includes_future_scheduled_statuses(
-    async_session_for_engine,
-):
-    await _assert_match_query_ids(
-        async_session_for_engine,
+@pytest.mark.parametrize(
+    "case",
+    [
         _MatchQueryCase(
             fetcher=live_messages._fetch_upcoming_matches,
             game="lol",
@@ -282,15 +259,6 @@ async def test_fetch_upcoming_matches_includes_future_scheduled_statuses(
                 ),
             ],
         ),
-    )
-
-
-@pytest.mark.asyncio
-async def test_fetch_upcoming_matches_includes_legacy_lol_slug_rows(
-    async_session_for_engine,
-):
-    await _assert_match_query_ids(
-        async_session_for_engine,
         _MatchQueryCase(
             fetcher=live_messages._fetch_upcoming_matches,
             game="lol",
@@ -307,15 +275,6 @@ async def test_fetch_upcoming_matches_includes_legacy_lol_slug_rows(
                 )
             ],
         ),
-    )
-
-
-@pytest.mark.asyncio
-async def test_fetch_running_matches_accepts_live_status_aliases(
-    async_session_for_engine,
-):
-    await _assert_match_query_ids(
-        async_session_for_engine,
         _MatchQueryCase(
             fetcher=live_messages._fetch_running_matches,
             game="lol",
@@ -331,4 +290,7 @@ async def test_fetch_running_matches_accepts_live_status_aliases(
                 )
             ],
         ),
-    )
+    ],
+)
+async def test_match_query_behaviors(async_session_for_engine, case):
+    await _assert_match_query_ids(async_session_for_engine, case)

--- a/tests/test_live_messages.py
+++ b/tests/test_live_messages.py
@@ -138,7 +138,9 @@ def test_build_upcoming_embed_uses_count_based_empty_state_message():
 
 
 @pytest.mark.asyncio
-async def test_fetch_running_matches_excludes_finished_results():
+async def test_fetch_running_matches_excludes_finished_results(
+    async_session_for_engine,
+):
     engine = create_engine("sqlite:///:memory:")
     SQLModel.metadata.create_all(engine)
 
@@ -187,38 +189,23 @@ async def test_fetch_running_matches_excludes_finished_results():
         )
         session.commit()
 
-    class _ResultWrapper:
-        def __init__(self, rows):
-            self._rows = rows
-
-        def all(self):
-            return self._rows
-
-    class _AsyncSession:
-        @staticmethod
-        async def exec(stmt):
-            with Session(engine) as session:
-                return _ResultWrapper(list(session.exec(stmt).all()))
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, exc_type, exc, tb):
-            _ = (exc_type, exc, tb)
-            return False
-
     with patch.object(
         live_messages,
         "get_async_session",
-        return_value=_AsyncSession(),
+        return_value=async_session_for_engine(engine),
     ):
         matches = await live_messages._fetch_running_matches("lol")
 
     assert [match.pandascore_id for match in matches] == [1]
 
 
-@pytest.mark.asyncio
-async def test_fetch_upcoming_matches_includes_future_scheduled_statuses():
+async def _assert_match_query_ids(
+    async_session_for_engine,
+    matches_to_create,
+    fetcher,
+    game: str,
+    expected_ids: list[int],
+) -> None:
     engine = create_engine("sqlite:///:memory:")
     SQLModel.metadata.create_all(engine)
 
@@ -226,7 +213,7 @@ async def test_fetch_upcoming_matches_includes_future_scheduled_statuses():
         contest = Contest(
             pandascore_league_id=10,
             pandascore_serie_id=20,
-            name="IEM Katowice",
+            name="Test Contest",
             start_date=datetime.now(timezone.utc),
             end_date=datetime.now(timezone.utc),
         )
@@ -234,138 +221,84 @@ async def test_fetch_upcoming_matches_includes_future_scheduled_statuses():
         session.commit()
         session.refresh(contest)
 
-        scheduled_match = Match(
-            contest_id=contest.id,
-            pandascore_id=10,
-            team1="Alpha",
-            team2="Beta",
-            status="scheduled",
-            game="lol",
-            scheduled_time=datetime.now(timezone.utc) + timedelta(hours=1),
-        )
-        finished_match = Match(
-            contest_id=contest.id,
-            pandascore_id=11,
-            team1="Gamma",
-            team2="Delta",
-            status="finished",
-            game="lol",
-            scheduled_time=datetime.now(timezone.utc) + timedelta(hours=2),
-        )
-        session.add(scheduled_match)
-        session.add(finished_match)
+        for match in matches_to_create:
+            match.contest_id = contest.id
+            session.add(match)
         session.commit()
-
-    class _ResultWrapper:
-        def __init__(self, rows):
-            self._rows = rows
-
-        def all(self):
-            return self._rows
-
-    class _AsyncSession:
-        @staticmethod
-        async def exec(stmt):
-            with Session(engine) as session:
-                return _ResultWrapper(list(session.exec(stmt).all()))
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, exc_type, exc, tb):
-            _ = (exc_type, exc, tb)
-            return False
 
     with patch.object(
         live_messages,
         "get_async_session",
-        return_value=_AsyncSession(),
+        return_value=async_session_for_engine(engine),
     ):
-        matches = await live_messages._fetch_upcoming_matches("lol")
+        matches = await fetcher(game)
 
-    assert [match.pandascore_id for match in matches] == [10]
+    assert [match.pandascore_id for match in matches] == expected_ids
 
 
 @pytest.mark.asyncio
-async def test_fetch_upcoming_matches_includes_legacy_lol_slug_rows():
-    engine = create_engine("sqlite:///:memory:")
-    SQLModel.metadata.create_all(engine)
-
-    with Session(engine) as session:
-        contest = Contest(
-            pandascore_league_id=30,
-            pandascore_serie_id=40,
-            name="LCK Spring",
-            start_date=datetime.now(timezone.utc),
-            end_date=datetime.now(timezone.utc),
-        )
-        session.add(contest)
-        session.commit()
-        session.refresh(contest)
-
-        session.add(
+async def test_fetch_upcoming_matches_includes_future_scheduled_statuses(
+    async_session_for_engine,
+):
+    await _assert_match_query_ids(
+        async_session_for_engine,
+        [
             Match(
-                contest_id=contest.id,
+                pandascore_id=10,
+                team1="Alpha",
+                team2="Beta",
+                status="scheduled",
+                game="lol",
+                scheduled_time=datetime.now(timezone.utc)
+                + timedelta(hours=1),
+            ),
+            Match(
+                pandascore_id=11,
+                team1="Gamma",
+                team2="Delta",
+                status="finished",
+                game="lol",
+                scheduled_time=datetime.now(timezone.utc)
+                + timedelta(hours=2),
+            ),
+        ],
+        live_messages._fetch_upcoming_matches,
+        "lol",
+        [10],
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_upcoming_matches_includes_legacy_lol_slug_rows(
+    async_session_for_engine,
+):
+    await _assert_match_query_ids(
+        async_session_for_engine,
+        [
+            Match(
                 pandascore_id=20,
                 team1="T1",
                 team2="GEN",
                 status="not_started",
                 game="league-of-legends",
-                scheduled_time=datetime.now(timezone.utc) + timedelta(hours=1),
+                scheduled_time=datetime.now(timezone.utc)
+                + timedelta(hours=1),
             )
-        )
-        session.commit()
-
-    class _ResultWrapper:
-        def __init__(self, rows):
-            self._rows = rows
-
-        def all(self):
-            return self._rows
-
-    class _AsyncSession:
-        @staticmethod
-        async def exec(stmt):
-            with Session(engine) as session:
-                return _ResultWrapper(list(session.exec(stmt).all()))
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, exc_type, exc, tb):
-            _ = (exc_type, exc, tb)
-            return False
-
-    with patch.object(
-        live_messages,
-        "get_async_session",
-        return_value=_AsyncSession(),
-    ):
-        matches = await live_messages._fetch_upcoming_matches("lol")
-
-    assert [match.pandascore_id for match in matches] == [20]
+        ],
+        live_messages._fetch_upcoming_matches,
+        "lol",
+        [20],
+    )
 
 
 @pytest.mark.asyncio
-async def test_fetch_running_matches_accepts_live_status_aliases():
-    engine = create_engine("sqlite:///:memory:")
-    SQLModel.metadata.create_all(engine)
-
-    with Session(engine) as session:
-        contest = Contest(
-            pandascore_league_id=50,
-            pandascore_serie_id=60,
-            name="LPL Spring",
-            start_date=datetime.now(timezone.utc),
-            end_date=datetime.now(timezone.utc),
-        )
-        session.add(contest)
-        session.commit()
-        session.refresh(contest)
-
-        session.add(
+async def test_fetch_running_matches_accepts_live_status_aliases(
+    async_session_for_engine,
+):
+    await _assert_match_query_ids(
+        async_session_for_engine,
+        [
             Match(
-                contest_id=contest.id,
                 pandascore_id=30,
                 team1="BLG",
                 team2="TES",
@@ -373,34 +306,8 @@ async def test_fetch_running_matches_accepts_live_status_aliases():
                 game="league-of-legends",
                 scheduled_time=datetime.now(timezone.utc),
             )
-        )
-        session.commit()
-
-    class _ResultWrapper:
-        def __init__(self, rows):
-            self._rows = rows
-
-        def all(self):
-            return self._rows
-
-    class _AsyncSession:
-        @staticmethod
-        async def exec(stmt):
-            with Session(engine) as session:
-                return _ResultWrapper(list(session.exec(stmt).all()))
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, exc_type, exc, tb):
-            _ = (exc_type, exc, tb)
-            return False
-
-    with patch.object(
-        live_messages,
-        "get_async_session",
-        return_value=_AsyncSession(),
-    ):
-        matches = await live_messages._fetch_running_matches("lol")
-
-    assert [match.pandascore_id for match in matches] == [30]
+        ],
+        live_messages._fetch_running_matches,
+        "lol",
+        [30],
+    )

--- a/tests/test_live_messages.py
+++ b/tests/test_live_messages.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -9,17 +10,52 @@ import src.live_messages as live_messages
 from src.models import Contest, Match, Result
 
 
-@pytest.mark.asyncio
-async def test_refresh_scope_creates_missing_live_message():
+@dataclass(frozen=True)
+class _RefreshScopeCase:
+    guild_id: int
+    channel_id: int
+    message_id: int
+    scope: str
+    embed_title: str
+    has_live_record: bool = False
+
+
+@dataclass(frozen=True)
+class _MatchQueryCase:
+    fetcher: object
+    game: str
+    expected_ids: list[int]
+    matches_to_create: list[Match]
+
+
+def _build_scope_case(
+    *,
+    guild_id: int,
+    channel_id: int,
+    message_id: int,
+    scope: str,
+    embed_title: str,
+    has_live_record: bool = False,
+) -> _RefreshScopeCase:
+    return _RefreshScopeCase(
+        guild_id=guild_id,
+        channel_id=channel_id,
+        message_id=message_id,
+        scope=scope,
+        embed_title=embed_title,
+        has_live_record=has_live_record,
+    )
+
+
+async def _assert_refresh_scope(case: _RefreshScopeCase) -> None:
     guild = MagicMock()
-    guild.id = 111
+    guild.id = case.guild_id
     guild.me = None
 
     channel = AsyncMock()
-    channel.id = 222
-    sent_message = AsyncMock()
-    sent_message.id = 333
-    channel.send.return_value = sent_message
+    channel.id = case.channel_id
+    message = AsyncMock()
+    message.id = case.message_id
 
     guild.get_channel.return_value = channel
     cfg = MagicMock(
@@ -27,64 +63,16 @@ async def test_refresh_scope_creates_missing_live_message():
         announcement_channel_id=None,
         enabled_games="lol",
     )
-    embed = discord.Embed(title="Upcoming")
-
-    with patch.object(
-        live_messages,
-        "_load_live_record",
-        new_callable=AsyncMock,
-        return_value=None,
-    ), patch.object(
-        live_messages,
-        "_build_live_message_embed",
-        new_callable=AsyncMock,
-        return_value=embed,
-    ), patch.object(
-        live_messages,
-        "_persist_live_message_pointer",
-        new_callable=AsyncMock,
-    ) as mock_persist:
-        await live_messages._refresh_guild_scope(
-            cfg,
-            live_messages.LiveMessageScope(
-                guild=guild,
-                game="lol",
-                scope="upcoming",
-            ),
+    embed = discord.Embed(title=case.embed_title)
+    live_record = None
+    if case.has_live_record:
+        channel.fetch_message.return_value = message
+        live_record = MagicMock(
+            channel_id=channel.id,
+            message_id=case.message_id,
         )
-
-    channel.send.assert_awaited_once_with(embed=embed)
-    mock_persist.assert_awaited_once_with(
-        live_messages.LiveMessageScope(
-            guild=guild,
-            game="lol",
-            scope="upcoming",
-        ),
-        channel.id,
-        sent_message.id,
-    )
-
-
-@pytest.mark.asyncio
-async def test_refresh_scope_edits_existing_live_message():
-    guild = MagicMock()
-    guild.id = 222
-    guild.me = None
-
-    channel = AsyncMock()
-    channel.id = 444
-    fetched_message = AsyncMock()
-    fetched_message.id = 555
-    channel.fetch_message.return_value = fetched_message
-
-    guild.get_channel.return_value = channel
-    cfg = MagicMock(
-        live_updates_channel_id=channel.id,
-        announcement_channel_id=None,
-        enabled_games="lol",
-    )
-    live_record = MagicMock(channel_id=channel.id, message_id=555)
-    embed = discord.Embed(title="Running")
+    else:
+        channel.send.return_value = message
 
     with patch.object(
         live_messages,
@@ -106,20 +94,51 @@ async def test_refresh_scope_edits_existing_live_message():
             live_messages.LiveMessageScope(
                 guild=guild,
                 game="lol",
-                scope="running",
+                scope=case.scope,
             ),
         )
 
-    fetched_message.edit.assert_awaited_once_with(embed=embed)
-    channel.send.assert_not_called()
+    if case.has_live_record:
+        message.edit.assert_awaited_once_with(embed=embed)
+        channel.send.assert_not_called()
+    else:
+        channel.send.assert_awaited_once_with(embed=embed)
+
     mock_persist.assert_awaited_once_with(
         live_messages.LiveMessageScope(
             guild=guild,
             game="lol",
-            scope="running",
+            scope=case.scope,
         ),
         channel.id,
-        live_record.message_id,
+        message.id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_refresh_scope_creates_missing_live_message():
+    await _assert_refresh_scope(
+        _build_scope_case(
+            guild_id=111,
+            channel_id=222,
+            message_id=333,
+            scope="upcoming",
+            embed_title="Upcoming",
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_refresh_scope_edits_existing_live_message():
+    await _assert_refresh_scope(
+        _build_scope_case(
+            guild_id=222,
+            channel_id=444,
+            message_id=555,
+            scope="running",
+            embed_title="Running",
+            has_live_record=True,
+        )
     )
 
 
@@ -200,11 +219,7 @@ async def test_fetch_running_matches_excludes_finished_results(
 
 
 async def _assert_match_query_ids(
-    async_session_for_engine,
-    matches_to_create,
-    fetcher,
-    game: str,
-    expected_ids: list[int],
+    async_session_for_engine, case: _MatchQueryCase
 ) -> None:
     engine = create_engine("sqlite:///:memory:")
     SQLModel.metadata.create_all(engine)
@@ -221,7 +236,7 @@ async def _assert_match_query_ids(
         session.commit()
         session.refresh(contest)
 
-        for match in matches_to_create:
+        for match in case.matches_to_create:
             match.contest_id = contest.id
             session.add(match)
         session.commit()
@@ -231,9 +246,9 @@ async def _assert_match_query_ids(
         "get_async_session",
         return_value=async_session_for_engine(engine),
     ):
-        matches = await fetcher(game)
+        matches = await case.fetcher(case.game)
 
-    assert [match.pandascore_id for match in matches] == expected_ids
+    assert [match.pandascore_id for match in matches] == case.expected_ids
 
 
 @pytest.mark.asyncio
@@ -242,29 +257,31 @@ async def test_fetch_upcoming_matches_includes_future_scheduled_statuses(
 ):
     await _assert_match_query_ids(
         async_session_for_engine,
-        [
-            Match(
-                pandascore_id=10,
-                team1="Alpha",
-                team2="Beta",
-                status="scheduled",
-                game="lol",
-                scheduled_time=datetime.now(timezone.utc)
-                + timedelta(hours=1),
-            ),
-            Match(
-                pandascore_id=11,
-                team1="Gamma",
-                team2="Delta",
-                status="finished",
-                game="lol",
-                scheduled_time=datetime.now(timezone.utc)
-                + timedelta(hours=2),
-            ),
-        ],
-        live_messages._fetch_upcoming_matches,
-        "lol",
-        [10],
+        _MatchQueryCase(
+            fetcher=live_messages._fetch_upcoming_matches,
+            game="lol",
+            expected_ids=[10],
+            matches_to_create=[
+                Match(
+                    pandascore_id=10,
+                    team1="Alpha",
+                    team2="Beta",
+                    status="scheduled",
+                    game="lol",
+                    scheduled_time=datetime.now(timezone.utc)
+                    + timedelta(hours=1),
+                ),
+                Match(
+                    pandascore_id=11,
+                    team1="Gamma",
+                    team2="Delta",
+                    status="finished",
+                    game="lol",
+                    scheduled_time=datetime.now(timezone.utc)
+                    + timedelta(hours=2),
+                ),
+            ],
+        ),
     )
 
 
@@ -274,20 +291,22 @@ async def test_fetch_upcoming_matches_includes_legacy_lol_slug_rows(
 ):
     await _assert_match_query_ids(
         async_session_for_engine,
-        [
-            Match(
-                pandascore_id=20,
-                team1="T1",
-                team2="GEN",
-                status="not_started",
-                game="league-of-legends",
-                scheduled_time=datetime.now(timezone.utc)
-                + timedelta(hours=1),
-            )
-        ],
-        live_messages._fetch_upcoming_matches,
-        "lol",
-        [20],
+        _MatchQueryCase(
+            fetcher=live_messages._fetch_upcoming_matches,
+            game="lol",
+            expected_ids=[20],
+            matches_to_create=[
+                Match(
+                    pandascore_id=20,
+                    team1="T1",
+                    team2="GEN",
+                    status="not_started",
+                    game="league-of-legends",
+                    scheduled_time=datetime.now(timezone.utc)
+                    + timedelta(hours=1),
+                )
+            ],
+        ),
     )
 
 
@@ -297,17 +316,19 @@ async def test_fetch_running_matches_accepts_live_status_aliases(
 ):
     await _assert_match_query_ids(
         async_session_for_engine,
-        [
-            Match(
-                pandascore_id=30,
-                team1="BLG",
-                team2="TES",
-                status="live",
-                game="league-of-legends",
-                scheduled_time=datetime.now(timezone.utc),
-            )
-        ],
-        live_messages._fetch_running_matches,
-        "lol",
-        [30],
+        _MatchQueryCase(
+            fetcher=live_messages._fetch_running_matches,
+            game="lol",
+            expected_ids=[30],
+            matches_to_create=[
+                Match(
+                    pandascore_id=30,
+                    team1="BLG",
+                    team2="TES",
+                    status="live",
+                    game="league-of-legends",
+                    scheduled_time=datetime.now(timezone.utc),
+                )
+            ],
+        ),
     )

--- a/tests/test_live_messages.py
+++ b/tests/test_live_messages.py
@@ -284,3 +284,123 @@ async def test_fetch_upcoming_matches_includes_future_scheduled_statuses():
         matches = await live_messages._fetch_upcoming_matches("lol")
 
     assert [match.pandascore_id for match in matches] == [10]
+
+
+@pytest.mark.asyncio
+async def test_fetch_upcoming_matches_includes_legacy_lol_slug_rows():
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        contest = Contest(
+            pandascore_league_id=30,
+            pandascore_serie_id=40,
+            name="LCK Spring",
+            start_date=datetime.now(timezone.utc),
+            end_date=datetime.now(timezone.utc),
+        )
+        session.add(contest)
+        session.commit()
+        session.refresh(contest)
+
+        session.add(
+            Match(
+                contest_id=contest.id,
+                pandascore_id=20,
+                team1="T1",
+                team2="GEN",
+                status="not_started",
+                game="league-of-legends",
+                scheduled_time=datetime.now(timezone.utc) + timedelta(hours=1),
+            )
+        )
+        session.commit()
+
+    class _ResultWrapper:
+        def __init__(self, rows):
+            self._rows = rows
+
+        def all(self):
+            return self._rows
+
+    class _AsyncSession:
+        @staticmethod
+        async def exec(stmt):
+            with Session(engine) as session:
+                return _ResultWrapper(list(session.exec(stmt).all()))
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            _ = (exc_type, exc, tb)
+            return False
+
+    with patch.object(
+        live_messages,
+        "get_async_session",
+        return_value=_AsyncSession(),
+    ):
+        matches = await live_messages._fetch_upcoming_matches("lol")
+
+    assert [match.pandascore_id for match in matches] == [20]
+
+
+@pytest.mark.asyncio
+async def test_fetch_running_matches_accepts_live_status_aliases():
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        contest = Contest(
+            pandascore_league_id=50,
+            pandascore_serie_id=60,
+            name="LPL Spring",
+            start_date=datetime.now(timezone.utc),
+            end_date=datetime.now(timezone.utc),
+        )
+        session.add(contest)
+        session.commit()
+        session.refresh(contest)
+
+        session.add(
+            Match(
+                contest_id=contest.id,
+                pandascore_id=30,
+                team1="BLG",
+                team2="TES",
+                status="live",
+                game="league-of-legends",
+                scheduled_time=datetime.now(timezone.utc),
+            )
+        )
+        session.commit()
+
+    class _ResultWrapper:
+        def __init__(self, rows):
+            self._rows = rows
+
+        def all(self):
+            return self._rows
+
+    class _AsyncSession:
+        @staticmethod
+        async def exec(stmt):
+            with Session(engine) as session:
+                return _ResultWrapper(list(session.exec(stmt).all()))
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            _ = (exc_type, exc, tb)
+            return False
+
+    with patch.object(
+        live_messages,
+        "get_async_session",
+        return_value=_AsyncSession(),
+    ):
+        matches = await live_messages._fetch_running_matches("lol")
+
+    assert [match.pandascore_id for match in matches] == [30]

--- a/tests/test_new_commands.py
+++ b/tests/test_new_commands.py
@@ -119,6 +119,30 @@ async def test_matches_view_by_day_no_matches(
 
 
 @pytest.mark.asyncio
+async def test_create_matches_embed_includes_game_label(mock_interaction):
+    contest = MagicMock()
+    contest.name = "LCK Spring"
+    match = Match(
+        id=1,
+        contest_id=1,
+        team1="T1",
+        team2="HLE",
+        scheduled_time=datetime.now(timezone.utc),
+        status="not_started",
+        game="league-of-legends",
+    )
+    match.contest = contest
+    match.result = None
+
+    embed = await matches.create_matches_embed(
+        "Test Matches", [match], mock_interaction
+    )
+
+    assert embed.fields
+    assert "**Game:** LoL" in embed.fields[0].value
+
+
+@pytest.mark.asyncio
 @patch("src.commands.leaderboard.get_session")
 async def test_leaderboard_command_empty(
     mock_get_session, mock_interaction, mock_session

--- a/tests/test_pandascore.py
+++ b/tests/test_pandascore.py
@@ -2,8 +2,12 @@
 Unit tests for PandaScore client and sync logic.
 """
 
+from datetime import datetime, timezone
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+from sqlmodel import SQLModel, Session, create_engine
+
+from src.models import Contest, Match
 
 
 def _make_mock_match(
@@ -15,6 +19,14 @@ def _make_mock_match(
     match.team1 = team1
     match.team2 = team2
     return match
+
+
+def _assert_match_data_game(
+    parser, match_data: dict, expected_game: str
+) -> None:
+    result = parser.extract_match_data(match_data, contest_id=1)
+    assert result is not None
+    assert result["game"] == expected_game
 
 
 class TestPandaScoreClient:
@@ -182,7 +194,9 @@ class TestLoLParser:
         assert result["best_of"] == 3
 
     @staticmethod
-    def test_extract_match_data_normalizes_lol_payload_slug(parser):
+    def test_extract_match_data_normalizes_lol_payload_slug(
+        parser,
+    ) -> None:
         match_data = {
             "id": 123456,
             "scheduled_at": "2024-03-15T10:00:00Z",
@@ -190,10 +204,7 @@ class TestLoLParser:
             "videogame": {"slug": "league-of-legends"},
             "videogame_title": "League of Legends",
         }
-
-        result = parser.extract_match_data(match_data, contest_id=1)
-        assert result is not None
-        assert result["game"] == "lol"
+        _assert_match_data_game(parser, match_data, "lol")
 
     @staticmethod
     def test_extract_match_data_uses_payload_game_slug(parser):
@@ -203,10 +214,7 @@ class TestLoLParser:
             "opponents": [],
             "videogame": {"slug": "lol"},
         }
-
-        result = parser.extract_match_data(match_data, contest_id=1)
-        assert result is not None
-        assert result["game"] == "lol"
+        _assert_match_data_game(parser, match_data, "lol")
 
     @staticmethod
     def test_extract_match_data_missing_opponents(parser):
@@ -324,10 +332,7 @@ class TestCS2Parser:
             "videogame": {"slug": "counterstrike"},
             "videogame_title": "Counter-Strike 2",
         }
-
-        result = parser.extract_match_data(match_data, contest_id=1)
-        assert result is not None
-        assert result["game"] == "cs2"
+        _assert_match_data_game(parser, match_data, "cs2")
 
 
 class TestPandaScoreSyncIntegration:
@@ -369,6 +374,60 @@ class TestPandaScoreSyncIntegration:
         ):
             result = await perform_pandascore_sync()
             assert result is None
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_reconcile_finished_matches_handles_legacy_lol_rows(
+        async_session_for_engine,
+    ) -> None:
+        from src import pandascore_sync
+
+        engine = create_engine("sqlite:///:memory:")
+        SQLModel.metadata.create_all(engine)
+
+        with Session(engine) as session:
+            contest = Contest(
+                pandascore_league_id=1,
+                pandascore_serie_id=2,
+                name="LCK Spring",
+                start_date=datetime.now(timezone.utc),
+                end_date=datetime.now(timezone.utc),
+            )
+            session.add(contest)
+            session.commit()
+            session.refresh(contest)
+
+            session.add(
+                Match(
+                    contest_id=contest.id,
+                    pandascore_id=77,
+                    team1="T1",
+                    team2="GEN",
+                    status="live",
+                    game="league-of-legends",
+                    scheduled_time=datetime.now(timezone.utc),
+                )
+            )
+            session.commit()
+
+        with patch.object(
+            pandascore_sync,
+            "get_async_session",
+            return_value=async_session_for_engine(engine),
+        ), patch.object(
+            pandascore_sync,
+            "_fetch_pandascore_match",
+            new_callable=AsyncMock,
+            return_value={"status": "finished"},
+        ) as mock_fetch, patch.object(
+            pandascore_sync,
+            "fetch_and_update_match_result",
+            new_callable=AsyncMock,
+        ) as mock_update:
+            await pandascore_sync._reconcile_finished_matches_for_game("lol")
+
+        mock_fetch.assert_awaited_once_with(77, "lol")
+        mock_update.assert_awaited_once_with(77, game_slug="lol")
 
     @staticmethod
     @pytest.mark.asyncio

--- a/tests/test_pandascore.py
+++ b/tests/test_pandascore.py
@@ -182,6 +182,20 @@ class TestLoLParser:
         assert result["best_of"] == 3
 
     @staticmethod
+    def test_extract_match_data_normalizes_lol_payload_slug(parser):
+        match_data = {
+            "id": 123456,
+            "scheduled_at": "2024-03-15T10:00:00Z",
+            "opponents": [],
+            "videogame": {"slug": "league-of-legends"},
+            "videogame_title": "League of Legends",
+        }
+
+        result = parser.extract_match_data(match_data, contest_id=1)
+        assert result is not None
+        assert result["game"] == "lol"
+
+    @staticmethod
     def test_extract_match_data_uses_payload_game_slug(parser):
         match_data = {
             "id": 123456,


### PR DESCRIPTION
## Summary

This PR restores LoL live-message visibility and adds game labeling to /matches.

## Root cause

LoL match rows could be stored with PandaScore's raw slug such as league-of-legends instead of the app's canonical internal slug lol. The canonical live-message queries filter by internal game slug, so those rows were invisible to the LoL upcoming and live messages even when the match data existed in the database.

## Changes

- add shared game-slug normalization so PandaScore slugs normalize to canonical internal values
- normalize LoL and CS2 parser output through the shared helper
- use canonical-aware game matching in live-message queries so legacy LoL rows still render during transition
- accept live status aliases like live and in_progress in the running-message query
- add a visible Game: line to each /matches entry using the same display names as the live-message system
- add regression coverage for real LoL PandaScore payloads, legacy LoL live-message rows, live-status aliases, and /matches embed formatting

## Validation

- python -m pytest
- python -m flake8 src tests alembic --jobs=1

Black remains unreliable in this shell because of the existing Windows multiprocessing/permission issue, but the changed files were kept in Black-compatible shape and no formatting diffs were left in the touched code before the environment hang recurred.