### PR TITLE
feat: add contest tiers to match displays

### DIFF
--- a/alembic/versions/7a4d1f2c9b8e_add_tier_to_contest.py
+++ b/alembic/versions/7a4d1f2c9b8e_add_tier_to_contest.py
@@ -1,0 +1,36 @@
+"""add_tier_to_contest
+
+Revision ID: 7a4d1f2c9b8e
+Revises: c1d2e3f4a5b6
+Create Date: 2026-03-14 21:30:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+
+revision = "7a4d1f2c9b8e"
+down_revision = "c1d2e3f4a5b6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("contest", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "tier", sqlmodel.sql.sqltypes.AutoString(), nullable=True
+            )
+        )
+        batch_op.create_index(
+            batch_op.f("ix_contest_tier"),
+            ["tier"],
+            unique=False,
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("contest", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_contest_tier"))
+        batch_op.drop_column("tier")

--- a/src/commands/matches.py
+++ b/src/commands/matches.py
@@ -11,9 +11,14 @@ from sqlmodel import Session
 
 from src.db import get_session
 from src.models import Contest, Match
+from src.match_display import (
+    format_match_heading,
+    format_match_metadata,
+    format_match_result_or_score,
+    format_match_time,
+)
 from src import crud
 from src.auth import is_admin
-from src.parsers.game_slug import game_display_name
 
 logger = logging.getLogger("esports-bot.commands.matches")
 
@@ -21,39 +26,16 @@ matches_group = app_commands.Group(
     name="matches", description="Commands for viewing and managing matches."
 )
 
-# Display helpers for matches embed
-STATUS_MAP = {
-    "finished": "✅ Finished",
-    "running": "🔴 Live",
-    "live": "🔴 Live",
-    "in_progress": "🔴 Live",
-    "not_started": "⏳ Upcoming",
-    "scheduled": "⏳ Upcoming",
-    "canceled": "❌ Canceled",
-    "postponed": "🕒 Postponed",
-}
-LIVE_STATUSES = ("running", "live", "in_progress")
-
 
 def _format_match_value(m: Match) -> str:
-    status_label = STATUS_MAP.get(
-        m.status, m.status.capitalize() if m.status else "Upcoming"
-    )
-    time_str = m.scheduled_time.strftime("%H:%M UTC")
-    value = (
-        f"**Game:** {game_display_name(getattr(m, 'game', None))}\n"
-        f"**Status:** {status_label}\n"
-        f"**Time:** {time_str}\n"
-        f"**Contest:** {m.contest.name if m.contest else 'Unknown'}"
-    )
-    if m.best_of:
-        value += f"\n**Format:** Best of {m.best_of}"
-    if m.result:
-        score_str = f" ({m.result.score})" if m.result.score else ""
-        value += f"\n**Result:** **{m.result.winner}** won{score_str}"
-    elif m.status in LIVE_STATUSES and m.last_announced_score:
-        value += f"\n**Current Score:** {m.last_announced_score}"
-    return value
+    lines = [
+        format_match_metadata(m),
+        format_match_time(m),
+    ]
+    result_or_score = format_match_result_or_score(m)
+    if result_or_score:
+        lines.append(result_or_score)
+    return "\n".join(lines)
 
 
 def _paginate_matches(ms: list[Match], info: tuple[int, int] | None):
@@ -202,7 +184,7 @@ async def create_matches_embed(
 
     for m in display_matches:
         embed.add_field(
-            name=f"{m.team1} vs {m.team2}",
+            name=format_match_heading(m),
             value=_format_match_value(m),
             inline=False,
         )

--- a/src/commands/pick.py
+++ b/src/commands/pick.py
@@ -9,6 +9,11 @@ from sqlalchemy.orm import selectinload
 from sqlmodel import select
 
 from src.db import get_session
+from src.match_display import (
+    format_match_heading,
+    format_match_metadata,
+    format_match_time,
+)
 from src.models import Match
 from src import crud
 
@@ -119,27 +124,17 @@ class PickView(discord.ui.View):
         match = self.current_match
         current_pick = self.user_picks.get(match.id)
 
-        contest_name = (
-            match.contest.name if match.contest else "Unknown Tournament"
-        )
-        timestamp = int(match.scheduled_time.timestamp())
-        time_str = f"<t:{timestamp}:F> (<t:{timestamp}:R>)"
-
         embed = discord.Embed(
             title=f"Match {self.current_index + 1} of {len(self.matches)}",
-            description=f"**{contest_name}**",
+            description="\n".join(
+                [
+                    f"**{format_match_heading(match)}**",
+                    format_match_metadata(match),
+                    format_match_time(match),
+                ]
+            ),
             color=discord.Color.blue(),
         )
-
-        embed.add_field(
-            name="Teams", value=f"{match.team1} vs {match.team2}", inline=False
-        )
-        embed.add_field(
-            name="Format",
-            value=f"Best of {match.best_of}" if match.best_of else "Best of ?",
-            inline=True,
-        )
-        embed.add_field(name="Time", value=time_str, inline=False)
 
         pick_status = f"✅ **{current_pick}**" if current_pick else "❌ None"
         if datetime.now(timezone.utc) >= match.scheduled_time:

--- a/src/contest_tier.py
+++ b/src/contest_tier.py
@@ -1,0 +1,60 @@
+from typing import Any, Optional
+
+TIER_DISPLAY = {
+    "S": "S-tier",
+    "A": "A-tier",
+    "B": "B-tier",
+    "C": "C-tier",
+    "D": "D-tier",
+}
+
+
+def normalize_contest_tier(raw_tier: Any) -> Optional[str]:
+    if raw_tier is None:
+        return None
+
+    value = str(raw_tier).strip().upper()
+    if not value:
+        return None
+
+    direct = value.replace(" ", "")
+    if direct in TIER_DISPLAY:
+        return direct
+
+    if direct.endswith("-TIER"):
+        base = direct.removesuffix("-TIER")
+        if base in TIER_DISPLAY:
+            return base
+
+    if direct.startswith("TIER"):
+        base = direct.removeprefix("TIER").lstrip("-:")
+        if base in TIER_DISPLAY:
+            return base
+
+    return None
+
+
+def extract_contest_tier(match_data: dict[str, Any]) -> Optional[str]:
+    league = match_data.get("league") or {}
+    serie = match_data.get("serie") or {}
+
+    candidates = (
+        match_data.get("tier"),
+        league.get("tier"),
+        serie.get("tier"),
+        match_data.get("tournament_tier"),
+        league.get("tournament_tier"),
+        serie.get("tournament_tier"),
+    )
+    for candidate in candidates:
+        normalized = normalize_contest_tier(candidate)
+        if normalized:
+            return normalized
+    return None
+
+
+def display_contest_tier(raw_tier: Optional[str]) -> Optional[str]:
+    normalized = normalize_contest_tier(raw_tier)
+    if normalized is None:
+        return None
+    return TIER_DISPLAY[normalized]

--- a/src/contest_tier.py
+++ b/src/contest_tier.py
@@ -9,6 +9,18 @@ TIER_DISPLAY = {
 }
 
 
+def _normalize_tier_prefix(value: str, prefix: str) -> Optional[str]:
+    if not value.startswith(prefix):
+        return None
+    return _normalize_tier_key(value.removeprefix(prefix).lstrip("-:"))
+
+
+def _normalize_tier_key(value: str) -> Optional[str]:
+    if value in TIER_DISPLAY:
+        return value
+    return None
+
+
 def normalize_contest_tier(raw_tier: Any) -> Optional[str]:
     if raw_tier is None:
         return None
@@ -18,18 +30,16 @@ def normalize_contest_tier(raw_tier: Any) -> Optional[str]:
         return None
 
     direct = value.replace(" ", "")
-    if direct in TIER_DISPLAY:
-        return direct
+    normalized = _normalize_tier_key(direct)
+    if normalized:
+        return normalized
 
     if direct.endswith("-TIER"):
-        base = direct.removesuffix("-TIER")
-        if base in TIER_DISPLAY:
-            return base
+        return _normalize_tier_key(direct.removesuffix("-TIER"))
 
-    if direct.startswith("TIER"):
-        base = direct.removeprefix("TIER").lstrip("-:")
-        if base in TIER_DISPLAY:
-            return base
+    normalized = _normalize_tier_prefix(direct, "TIER")
+    if normalized:
+        return normalized
 
     return None
 

--- a/src/crud/contest.py
+++ b/src/crud/contest.py
@@ -27,12 +27,13 @@ async def upsert_contest(
 
     The function upserts a Contest by `leaguepedia_id`, creating a new
     record if none exists or updating the existing record. Only
-    `name`, `start_date`, and `end_date` are considered for updates.
+    `name`, `start_date`, `end_date`, and `tier` are considered for
+    updates.
 
     Parameters:
         contest_data (dict): Mapping of contest fields. Must include
-            `leaguepedia_id`. May include `name`, `start_date`, and
-            `end_date`.
+            `leaguepedia_id`. May include `name`, `start_date`,
+            `end_date`, and `tier`.
 
     Returns:
         Contest or None: The created or updated Contest, or `None` if
@@ -59,7 +60,7 @@ async def upsert_contest_by_pandascore(
     Parameters:
         contest_data (dict): Mapping of contest fields. Must include
             `pandascore_league_id` and `pandascore_serie_id`. May include
-            `name`, `start_date`, and `end_date`.
+            `name`, `start_date`, `end_date`, and `tier`.
 
     Returns:
         Contest or None: The created or updated Contest, or None if

--- a/src/crud/contest.py
+++ b/src/crud/contest.py
@@ -16,6 +16,7 @@ class ContestUpdateParams:
     name: Optional[str] = None
     start_date: Optional[datetime] = None
     end_date: Optional[datetime] = None
+    tier: Optional[str] = None
 
 
 async def upsert_contest(
@@ -41,7 +42,7 @@ async def upsert_contest(
         session,
         Contest,
         contest_data,
-        update_keys=["name", "start_date", "end_date"],
+        update_keys=["name", "start_date", "end_date", "tier"],
     )
 
 
@@ -101,7 +102,7 @@ async def upsert_contest_by_pandascore(
 def _update_contest_from_data(contest: Contest, contest_data: dict) -> None:
     """Updates existing contest fields from data."""
     logger.info("Updating existing contest: %s", contest.name)
-    for key in ["name", "start_date", "end_date", "image_url"]:
+    for key in ["name", "start_date", "end_date", "image_url", "tier"]:
         if key in contest_data and contest_data[key] is not None:
             setattr(contest, key, contest_data[key])
 
@@ -153,6 +154,7 @@ def create_contest(session: Session, contest_data: dict) -> Contest:
     start_date = contest_data.get("start_date")
     end_date = contest_data.get("end_date")
     leaguepedia_id = contest_data.get("leaguepedia_id")
+    tier = contest_data.get("tier")
 
     logger.info("Creating contest: %s", name)
     contest = Contest(
@@ -160,6 +162,7 @@ def create_contest(session: Session, contest_data: dict) -> Contest:
         start_date=start_date,
         end_date=end_date,
         leaguepedia_id=leaguepedia_id,
+        tier=tier,
     )
     _save_and_refresh(session, contest)
     logger.info("Created contest with ID: %s", contest.id)
@@ -203,6 +206,8 @@ def update_contest(
         contest.start_date = params.start_date
     if params.end_date is not None:
         contest.end_date = params.end_date
+    if params.tier is not None:
+        contest.tier = params.tier
     _save_and_refresh(session, contest)
     logger.info("Updated contest ID: %s", contest_id)
     return contest

--- a/src/live_messages.py
+++ b/src/live_messages.py
@@ -19,6 +19,7 @@ from src.db import get_async_session
 from src.models import Match, Result
 from src.parsers.factory import get_supported_game_slugs
 from src.parsers.game_slug import game_display_name, game_query_slugs
+from src.contest_tier import display_contest_tier
 
 logger = logging.getLogger(__name__)
 
@@ -506,7 +507,11 @@ def _format_result_entry(entry: tuple[Match, Result]) -> str:
 
 def _contest_name(match: Match) -> str:
     contest = getattr(match, "contest", None)
-    return getattr(contest, "name", "Unknown contest")
+    name = getattr(contest, "name", "Unknown contest")
+    tier = display_contest_tier(getattr(contest, "tier", None))
+    if tier:
+        return f"{name} • {tier}"
+    return name
 
 
 def _best_of_suffix(match: Match) -> str:

--- a/src/match_display.py
+++ b/src/match_display.py
@@ -1,0 +1,61 @@
+from typing import Optional
+
+from src.contest_tier import display_contest_tier
+from src.parsers.game_slug import game_display_name
+
+STATUS_BADGES = {
+    "finished": "✅ Finished",
+    "running": "🔴 Live",
+    "live": "🔴 Live",
+    "in_progress": "🔴 Live",
+    "not_started": "⏳ Upcoming",
+    "scheduled": "⏳ Upcoming",
+    "canceled": "❌ Canceled",
+    "postponed": "🕒 Postponed",
+}
+LIVE_STATUSES = ("running", "live", "in_progress")
+
+
+def status_badge(status: Optional[str]) -> str:
+    if not status:
+        return "⏳ Upcoming"
+    return STATUS_BADGES.get(status, status.capitalize())
+
+
+def format_match_heading(match) -> str:
+    return f"{match.team1} vs {match.team2} — {status_badge(match.status)}"
+
+
+def format_match_metadata(match) -> str:
+    contest = getattr(match, "contest", None)
+    contest_name = getattr(contest, "name", "Unknown contest")
+    parts = [contest_name]
+
+    tier = display_contest_tier(getattr(contest, "tier", None))
+    if tier:
+        parts.append(tier)
+
+    parts.append(game_display_name(getattr(match, "game", None)))
+    if getattr(match, "best_of", None):
+        parts.append(f"Bo{match.best_of}")
+
+    return " • ".join(parts)
+
+
+def format_match_time(match) -> str:
+    timestamp = int(match.scheduled_time.timestamp())
+    return f"<t:{timestamp}:F> • <t:{timestamp}:R>"
+
+
+def format_match_result_or_score(match) -> Optional[str]:
+    result = getattr(match, "result", None)
+    if result:
+        score = f" ({result.score})" if getattr(result, "score", None) else ""
+        return f"Final: **{result.winner}** won{score}"
+
+    if getattr(match, "status", None) in LIVE_STATUSES and getattr(
+        match, "last_announced_score", None
+    ):
+        return f"Live score: {match.last_announced_score}"
+
+    return None

--- a/src/models.py
+++ b/src/models.py
@@ -72,6 +72,7 @@ class Contest(SQLModel, table=True):
     pandascore_serie_id: Optional[int] = Field(default=None, index=True)
     name: str = Field(index=True)
     image_url: Optional[str] = Field(default=None)
+    tier: Optional[str] = Field(default=None, index=True)
     __table_args__ = (
         sa.UniqueConstraint(
             "pandascore_league_id",

--- a/src/parsers/cs2.py
+++ b/src/parsers/cs2.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from typing import Any, Optional
 
 from src.parsers.base import PandaScoreParser
+from src.contest_tier import extract_contest_tier
 from src.parsers.game_slug import normalize_game_slug
 
 logger = logging.getLogger(__name__)
@@ -102,6 +103,7 @@ class CS2Parser(PandaScoreParser):
             "start_date": scheduled_at or now,
             "end_date": scheduled_at or now,
             "image_url": league.get("image_url"),
+            "tier": extract_contest_tier(match_data),
         }
 
     @staticmethod

--- a/src/parsers/lol.py
+++ b/src/parsers/lol.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from typing import Optional, Dict, Any, Tuple
 
 from src.parsers.base import PandaScoreParser
+from src.contest_tier import extract_contest_tier
 from src.parsers.game_slug import normalize_game_slug
 
 logger = logging.getLogger(__name__)
@@ -78,6 +79,7 @@ class LoLParser(PandaScoreParser):
             "start_date": scheduled_at or now,
             "end_date": scheduled_at or now,
             "image_url": league.get("image_url"),
+            "tier": extract_contest_tier(match_data),
         }
 
     @staticmethod

--- a/tests/commands/test_pick_view.py
+++ b/tests/commands/test_pick_view.py
@@ -6,37 +6,52 @@ from src.commands.pick import PickView
 from src.models import Match, Contest
 
 
-@pytest.fixture
-def mock_match():
+def _build_match(
+    *,
+    match_id: int,
+    team1: str,
+    team2: str,
+    contest_name: str,
+    days_from_now: int,
+    best_of: int,
+) -> Match:
+    now = datetime.now(timezone.utc)
     return Match(
-        id=1,
-        team1="T1",
-        team2="T2",
-        scheduled_time=datetime.now(timezone.utc) + timedelta(days=1),
+        id=match_id,
+        team1=team1,
+        team2=team2,
+        scheduled_time=now + timedelta(days=days_from_now),
         contest=Contest(
-            name="Worlds",
-            start_date=datetime.now(timezone.utc),
-            end_date=datetime.now(timezone.utc),
+            name=contest_name,
+            start_date=now,
+            end_date=now,
         ),
-        best_of=1,
+        best_of=best_of,
         contest_id=1,
     )
 
 
 @pytest.fixture
+def mock_match():
+    return _build_match(
+        match_id=1,
+        team1="T1",
+        team2="T2",
+        contest_name="Worlds",
+        days_from_now=1,
+        best_of=1,
+    )
+
+
+@pytest.fixture
 def mock_matches(mock_match):
-    m2 = Match(
-        id=2,
+    m2 = _build_match(
+        match_id=2,
         team1="G2",
         team2="FNC",
-        scheduled_time=datetime.now(timezone.utc) + timedelta(days=2),
-        contest=Contest(
-            name="LEC",
-            start_date=datetime.now(timezone.utc),
-            end_date=datetime.now(timezone.utc),
-        ),
+        contest_name="LEC",
+        days_from_now=2,
         best_of=3,
-        contest_id=1,
     )
     return [mock_match, m2]
 

--- a/tests/commands/test_pick_view.py
+++ b/tests/commands/test_pick_view.py
@@ -37,32 +37,34 @@ def _build_match(case: MatchFixtureCase) -> Match:
 
 
 @pytest.fixture
-def mock_match():
-    return _build_match(
-        MatchFixtureCase(
-            match_id=1,
-            team1="T1",
-            team2="T2",
-            contest_name="Worlds",
-            days_from_now=1,
-            best_of=1,
-        )
-    )
+def mock_matches():
+    return [
+        _build_match(
+            MatchFixtureCase(
+                match_id=1,
+                team1="T1",
+                team2="T2",
+                contest_name="Worlds",
+                days_from_now=1,
+                best_of=1,
+            )
+        ),
+        _build_match(
+            MatchFixtureCase(
+                match_id=2,
+                team1="G2",
+                team2="FNC",
+                contest_name="LEC",
+                days_from_now=2,
+                best_of=3,
+            )
+        ),
+    ]
 
 
 @pytest.fixture
-def mock_matches(mock_match):
-    m2 = _build_match(
-        MatchFixtureCase(
-            match_id=2,
-            team1="G2",
-            team2="FNC",
-            contest_name="LEC",
-            days_from_now=2,
-            best_of=3,
-        )
-    )
-    return [mock_match, m2]
+def mock_match(mock_matches):
+    return mock_matches[0]
 
 
 @pytest.mark.asyncio

--- a/tests/commands/test_pick_view.py
+++ b/tests/commands/test_pick_view.py
@@ -1,32 +1,37 @@
+from dataclasses import dataclass
+from datetime import datetime, timezone, timedelta
+
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
-from datetime import datetime, timezone, timedelta
+
 import discord
 from src.commands.pick import PickView
 from src.models import Match, Contest
 
 
-def _build_match(
-    *,
-    match_id: int,
-    team1: str,
-    team2: str,
-    contest_name: str,
-    days_from_now: int,
-    best_of: int,
-) -> Match:
+@dataclass(frozen=True)
+class MatchFixtureCase:
+    match_id: int
+    team1: str
+    team2: str
+    contest_name: str
+    days_from_now: int
+    best_of: int
+
+
+def _build_match(case: MatchFixtureCase) -> Match:
     now = datetime.now(timezone.utc)
     return Match(
-        id=match_id,
-        team1=team1,
-        team2=team2,
-        scheduled_time=now + timedelta(days=days_from_now),
+        id=case.match_id,
+        team1=case.team1,
+        team2=case.team2,
+        scheduled_time=now + timedelta(days=case.days_from_now),
         contest=Contest(
-            name=contest_name,
+            name=case.contest_name,
             start_date=now,
             end_date=now,
         ),
-        best_of=best_of,
+        best_of=case.best_of,
         contest_id=1,
     )
 
@@ -34,24 +39,28 @@ def _build_match(
 @pytest.fixture
 def mock_match():
     return _build_match(
-        match_id=1,
-        team1="T1",
-        team2="T2",
-        contest_name="Worlds",
-        days_from_now=1,
-        best_of=1,
+        MatchFixtureCase(
+            match_id=1,
+            team1="T1",
+            team2="T2",
+            contest_name="Worlds",
+            days_from_now=1,
+            best_of=1,
+        )
     )
 
 
 @pytest.fixture
 def mock_matches(mock_match):
     m2 = _build_match(
-        match_id=2,
-        team1="G2",
-        team2="FNC",
-        contest_name="LEC",
-        days_from_now=2,
-        best_of=3,
+        MatchFixtureCase(
+            match_id=2,
+            team1="G2",
+            team2="FNC",
+            contest_name="LEC",
+            days_from_now=2,
+            best_of=3,
+        )
     )
     return [mock_match, m2]
 

--- a/tests/commands/test_pick_view.py
+++ b/tests/commands/test_pick_view.py
@@ -131,3 +131,16 @@ async def test_pick_view_locked_match(mock_matches):
     pick_field = next((f for f in embed.fields if f.name == "Your Pick"), None)
     assert pick_field is not None
     assert "(Locked)" in pick_field.value
+
+
+@pytest.mark.asyncio
+async def test_pick_view_embed_uses_compact_match_metadata(mock_match):
+    mock_match.game = "lol"
+    mock_match.contest.tier = "S"
+
+    view = PickView(matches=[mock_match], user_picks={}, user_id=123)
+    embed = view.get_embed()
+
+    assert "**T1 vs T2 — ⏳ Upcoming**" in embed.description
+    assert "Worlds • S-tier • LoL • Bo1" in embed.description
+    assert "<t:" in embed.description

--- a/tests/test_contest_tier.py
+++ b/tests/test_contest_tier.py
@@ -1,0 +1,85 @@
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from sqlmodel import SQLModel, create_engine
+from sqlmodel.ext.asyncio.session import AsyncSession
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from src.crud.contest import (
+    get_contest_by_pandascore_ids,
+    upsert_contest_by_pandascore,
+)
+from src.parsers.lol import LoLParser
+
+
+def test_lol_parser_extract_contest_data_includes_tier():
+    parser = LoLParser()
+    match_data = {
+        "league": {
+            "id": 1,
+            "name": "LCS",
+            "image_url": "http://img",
+            "tier": "S-tier",
+        },
+        "serie": {
+            "id": 10,
+            "name": "Spring",
+            "full_name": "Spring Split 2024",
+        },
+        "scheduled_at": "2024-03-15T10:00:00Z",
+    }
+
+    result = parser.extract_contest_data(match_data)
+    assert result["pandascore_league_id"] == 1
+    assert result["pandascore_serie_id"] == 10
+    assert "LCS" in result["name"]
+    assert "Spring" in result["name"]
+    assert result["image_url"] == "http://img"
+    assert result["tier"] == "S"
+
+
+@pytest.mark.asyncio
+async def test_upsert_contest_by_pandascore_persists_tier():
+    temp_root = Path(".pytest_tmp")
+    temp_root.mkdir(exist_ok=True)
+    db_path = temp_root / f"contest-tier-{uuid4().hex}.db"
+    sync_engine = create_engine(f"sqlite:///{db_path}")
+    SQLModel.metadata.create_all(sync_engine)
+    async_engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+
+    try:
+        async with AsyncSession(async_engine) as session:
+            contest = await upsert_contest_by_pandascore(
+                session,
+                {
+                    "pandascore_league_id": 1,
+                    "pandascore_serie_id": 2,
+                    "name": "LCK Spring",
+                    "start_date": datetime(
+                        2026, 3, 14, 10, 0, tzinfo=timezone.utc
+                    ),
+                    "end_date": datetime(
+                        2026, 3, 14, 10, 0, tzinfo=timezone.utc
+                    ),
+                    "tier": "S",
+                },
+            )
+            assert contest is not None
+            await session.commit()
+
+        async with AsyncSession(async_engine) as session:
+            persisted = await get_contest_by_pandascore_ids(
+                session,
+                1,
+                2,
+            )
+
+        assert persisted is not None
+        assert persisted.tier == "S"
+    finally:
+        sync_engine.dispose()
+        await async_engine.dispose()
+        if db_path.exists():
+            db_path.unlink()

--- a/tests/test_matches_result_display.py
+++ b/tests/test_matches_result_display.py
@@ -16,6 +16,7 @@ async def test_create_matches_embed_with_result():
     # Use MagicMock with `spec` to avoid SQLModel validation/construct
     contest = MagicMock(spec=Contest)
     contest.name = "Test Tournament"
+    contest.tier = None
 
     match_no_result = MagicMock(spec=Match)
     match_no_result.team1 = "Team A"
@@ -27,6 +28,7 @@ async def test_create_matches_embed_with_result():
     match_no_result.result = None
     match_no_result.status = "not_started"
     match_no_result.best_of = 3
+    match_no_result.game = "lol"
     match_no_result.last_announced_score = None
 
     match_with_result = MagicMock(spec=Match)
@@ -38,6 +40,7 @@ async def test_create_matches_embed_with_result():
     match_with_result.contest = contest
     match_with_result.status = "finished"
     match_with_result.best_of = 3
+    match_with_result.game = "cs2"
     match_with_result.last_announced_score = None
     result = MagicMock(spec=Result)
     result.winner = "Team C"
@@ -53,14 +56,42 @@ async def test_create_matches_embed_with_result():
     assert len(embed.fields) == 2
 
     # Field 0: No result
-    assert embed.fields[0].name == "Team A vs Team B"
-    assert "Result" not in embed.fields[0].value
-    assert "**Status:** ⏳ Upcoming" in embed.fields[0].value
+    assert embed.fields[0].name == "Team A vs Team B — ⏳ Upcoming"
+    assert "Final:" not in embed.fields[0].value
+    assert "Test Tournament • LoL • Bo3" in embed.fields[0].value
+    assert "<t:" in embed.fields[0].value
 
     # Field 1: With result
-    assert embed.fields[1].name == "Team C vs Team D"
-    assert "Result:** **Team C** won (2-0)" in embed.fields[1].value
-    assert "**Status:** ✅ Finished" in embed.fields[1].value
+    assert embed.fields[1].name == "Team C vs Team D — ✅ Finished"
+    assert "Final: **Team C** won (2-0)" in embed.fields[1].value
+    assert "Test Tournament • CS2 • Bo3" in embed.fields[1].value
+
+
+@pytest.mark.asyncio
+async def test_create_matches_embed_with_tier_metadata():
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.user.display_name = "TestUser"
+    interaction.user.avatar = None
+
+    contest = MagicMock(spec=Contest)
+    contest.name = "First Stand"
+    contest.tier = "S"
+
+    match = MagicMock(spec=Match)
+    match.team1 = "T1"
+    match.team2 = "GEN"
+    match.scheduled_time = datetime(2025, 12, 26, 18, 0, tzinfo=timezone.utc)
+    match.contest = contest
+    match.result = None
+    match.status = "not_started"
+    match.best_of = 5
+    match.game = "lol"
+    match.last_announced_score = None
+
+    embed = await create_matches_embed("Tier Test", [match], interaction)
+
+    assert len(embed.fields) == 1
+    assert "First Stand • S-tier • LoL • Bo5" in embed.fields[0].value
 
 
 @pytest.mark.asyncio

--- a/tests/test_new_commands.py
+++ b/tests/test_new_commands.py
@@ -20,6 +20,7 @@ class MatchEmbedCase:
     best_of: int | None
     expected_text: str
 
+
 # --- Mocks and Test Data ---
 
 

--- a/tests/test_new_commands.py
+++ b/tests/test_new_commands.py
@@ -1,13 +1,24 @@
 # tests/test_new_commands.py
 
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
-from datetime import datetime, timezone
 
 import discord
 
 from src.commands import pick, picks, stats, matches, result, leaderboard
 from src.models import Match, Pick as PickModel
+
+
+@dataclass(frozen=True)
+class MatchEmbedCase:
+    contest_name: str
+    contest_tier: str | None
+    game: str
+    best_of: int | None
+    expected_text: str
 
 # --- Mocks and Test Data ---
 
@@ -120,23 +131,28 @@ async def test_matches_view_by_day_no_matches(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "contest_name,contest_tier,game,best_of,expected_text",
+    "case",
     [
-        ("LCK Spring", None, "league-of-legends", None, "LCK Spring • LoL"),
-        ("First Stand", "A", "lol", 5, "First Stand • A-tier • LoL • Bo5"),
+        MatchEmbedCase(
+            "LCK Spring",
+            None,
+            "league-of-legends",
+            None,
+            "LCK Spring • LoL",
+        ),
+        MatchEmbedCase(
+            "First Stand",
+            "A",
+            "lol",
+            5,
+            "First Stand • A-tier • LoL • Bo5",
+        ),
     ],
 )
-async def test_create_matches_embed_metadata(
-    mock_interaction,
-    contest_name,
-    contest_tier,
-    game,
-    best_of,
-    expected_text,
-):
+async def test_create_matches_embed_metadata(mock_interaction, case):
     contest = MagicMock()
-    contest.name = contest_name
-    contest.tier = contest_tier
+    contest.name = case.contest_name
+    contest.tier = case.contest_tier
     match = Match(
         id=1,
         contest_id=1,
@@ -144,8 +160,8 @@ async def test_create_matches_embed_metadata(
         team2="HLE",
         scheduled_time=datetime.now(timezone.utc),
         status="not_started",
-        game=game,
-        best_of=best_of,
+        game=case.game,
+        best_of=case.best_of,
     )
     match.contest = contest
     match.result = None
@@ -155,7 +171,7 @@ async def test_create_matches_embed_metadata(
     )
 
     assert embed.fields
-    assert expected_text in embed.fields[0].value
+    assert case.expected_text in embed.fields[0].value
 
 
 @pytest.mark.asyncio

--- a/tests/test_new_commands.py
+++ b/tests/test_new_commands.py
@@ -139,7 +139,35 @@ async def test_create_matches_embed_includes_game_label(mock_interaction):
     )
 
     assert embed.fields
-    assert "**Game:** LoL" in embed.fields[0].value
+    assert "LCK Spring • LoL" in embed.fields[0].value
+
+
+@pytest.mark.asyncio
+async def test_create_matches_embed_includes_tier_when_present(
+    mock_interaction,
+):
+    contest = MagicMock()
+    contest.name = "First Stand"
+    contest.tier = "A"
+    match = Match(
+        id=1,
+        contest_id=1,
+        team1="T1",
+        team2="HLE",
+        scheduled_time=datetime.now(timezone.utc),
+        status="not_started",
+        game="lol",
+        best_of=5,
+    )
+    match.contest = contest
+    match.result = None
+
+    embed = await matches.create_matches_embed(
+        "Test Matches", [match], mock_interaction
+    )
+
+    assert embed.fields
+    assert "First Stand • A-tier • LoL • Bo5" in embed.fields[0].value
 
 
 @pytest.mark.asyncio

--- a/tests/test_new_commands.py
+++ b/tests/test_new_commands.py
@@ -119,36 +119,24 @@ async def test_matches_view_by_day_no_matches(
 
 
 @pytest.mark.asyncio
-async def test_create_matches_embed_includes_game_label(mock_interaction):
-    contest = MagicMock()
-    contest.name = "LCK Spring"
-    match = Match(
-        id=1,
-        contest_id=1,
-        team1="T1",
-        team2="HLE",
-        scheduled_time=datetime.now(timezone.utc),
-        status="not_started",
-        game="league-of-legends",
-    )
-    match.contest = contest
-    match.result = None
-
-    embed = await matches.create_matches_embed(
-        "Test Matches", [match], mock_interaction
-    )
-
-    assert embed.fields
-    assert "LCK Spring • LoL" in embed.fields[0].value
-
-
-@pytest.mark.asyncio
-async def test_create_matches_embed_includes_tier_when_present(
+@pytest.mark.parametrize(
+    "contest_name,contest_tier,game,best_of,expected_text",
+    [
+        ("LCK Spring", None, "league-of-legends", None, "LCK Spring • LoL"),
+        ("First Stand", "A", "lol", 5, "First Stand • A-tier • LoL • Bo5"),
+    ],
+)
+async def test_create_matches_embed_metadata(
     mock_interaction,
+    contest_name,
+    contest_tier,
+    game,
+    best_of,
+    expected_text,
 ):
     contest = MagicMock()
-    contest.name = "First Stand"
-    contest.tier = "A"
+    contest.name = contest_name
+    contest.tier = contest_tier
     match = Match(
         id=1,
         contest_id=1,
@@ -156,8 +144,8 @@ async def test_create_matches_embed_includes_tier_when_present(
         team2="HLE",
         scheduled_time=datetime.now(timezone.utc),
         status="not_started",
-        game="lol",
-        best_of=5,
+        game=game,
+        best_of=best_of,
     )
     match.contest = contest
     match.result = None
@@ -167,7 +155,7 @@ async def test_create_matches_embed_includes_tier_when_present(
     )
 
     assert embed.fields
-    assert "First Stand • A-tier • LoL • Bo5" in embed.fields[0].value
+    assert expected_text in embed.fields[0].value
 
 
 @pytest.mark.asyncio

--- a/tests/test_pandascore.py
+++ b/tests/test_pandascore.py
@@ -3,8 +3,6 @@ Unit tests for PandaScore client and sync logic.
 """
 
 from datetime import datetime, timezone
-from pathlib import Path
-from uuid import uuid4
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -151,32 +149,6 @@ class TestLoLParser:
         """Test extracting team data with missing opponent key."""
         result = parser.extract_team_data({})
         assert result is None
-
-    @staticmethod
-    def test_extract_contest_data(parser):
-        """Test extracting contest data from match."""
-        match_data = {
-            "league": {
-                "id": 1,
-                "name": "LCS",
-                "image_url": "http://img",
-                "tier": "S-tier",
-            },
-            "serie": {
-                "id": 10,
-                "name": "Spring",
-                "full_name": "Spring Split 2024",
-            },
-            "scheduled_at": "2024-03-15T10:00:00Z",
-        }
-
-        result = parser.extract_contest_data(match_data)
-        assert result["pandascore_league_id"] == 1
-        assert result["pandascore_serie_id"] == 10
-        assert "LCS" in result["name"]
-        assert "Spring" in result["name"]
-        assert result["image_url"] == "http://img"
-        assert result["tier"] == "S"
 
     @staticmethod
     def test_extract_match_data_valid(parser):
@@ -553,59 +525,6 @@ class TestPandaScoreSyncIntegration:
             call.kwargs["game"] for call in mock_fetch.await_args_list
         }
         assert requested_games == {"lol", "cs2"}
-
-    @staticmethod
-    @pytest.mark.asyncio
-    async def test_upsert_contest_by_pandascore_persists_tier():
-        from sqlmodel.ext.asyncio.session import AsyncSession
-        from sqlalchemy.ext.asyncio import create_async_engine
-
-        from src.crud.contest import (
-            get_contest_by_pandascore_ids,
-            upsert_contest_by_pandascore,
-        )
-
-        temp_root = Path(".pytest_tmp")
-        temp_root.mkdir(exist_ok=True)
-        db_path = temp_root / f"contest-tier-{uuid4().hex}.db"
-        sync_engine = create_engine(f"sqlite:///{db_path}")
-        SQLModel.metadata.create_all(sync_engine)
-        async_engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
-
-        try:
-            async with AsyncSession(async_engine) as session:
-                contest = await upsert_contest_by_pandascore(
-                    session,
-                    {
-                        "pandascore_league_id": 1,
-                        "pandascore_serie_id": 2,
-                        "name": "LCK Spring",
-                        "start_date": datetime(
-                            2026, 3, 14, 10, 0, tzinfo=timezone.utc
-                        ),
-                        "end_date": datetime(
-                            2026, 3, 14, 10, 0, tzinfo=timezone.utc
-                        ),
-                        "tier": "S",
-                    },
-                )
-                assert contest is not None
-                await session.commit()
-
-            async with AsyncSession(async_engine) as session:
-                persisted = await get_contest_by_pandascore_ids(
-                    session,
-                    1,
-                    2,
-                )
-
-            assert persisted is not None
-            assert persisted.tier == "S"
-        finally:
-            sync_engine.dispose()
-            await async_engine.dispose()
-            if db_path.exists():
-                db_path.unlink()
 
 
 class TestPandaScoreClientRateLimiting:

--- a/tests/test_pandascore.py
+++ b/tests/test_pandascore.py
@@ -3,8 +3,10 @@ Unit tests for PandaScore client and sync logic.
 """
 
 from datetime import datetime, timezone
-import pytest
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 from sqlmodel import SQLModel, Session, create_engine
 
 from src.models import Contest, Match
@@ -153,7 +155,12 @@ class TestLoLParser:
     def test_extract_contest_data(parser):
         """Test extracting contest data from match."""
         match_data = {
-            "league": {"id": 1, "name": "LCS", "image_url": "http://img"},
+            "league": {
+                "id": 1,
+                "name": "LCS",
+                "image_url": "http://img",
+                "tier": "S-tier",
+            },
             "serie": {
                 "id": 10,
                 "name": "Spring",
@@ -168,6 +175,7 @@ class TestLoLParser:
         assert "LCS" in result["name"]
         assert "Spring" in result["name"]
         assert result["image_url"] == "http://img"
+        assert result["tier"] == "S"
 
     @staticmethod
     def test_extract_match_data_valid(parser):
@@ -544,6 +552,48 @@ class TestPandaScoreSyncIntegration:
             call.kwargs["game"] for call in mock_fetch.await_args_list
         }
         assert requested_games == {"lol", "cs2"}
+
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_upsert_contest_by_pandascore_persists_tier():
+        from sqlmodel.ext.asyncio.session import AsyncSession
+        from sqlalchemy.ext.asyncio import create_async_engine
+
+        from src.crud.contest import upsert_contest_by_pandascore
+
+        db_path = Path("data") / "contest-tier-test.db"
+        db_path.parent.mkdir(exist_ok=True)
+        if db_path.exists():
+            db_path.unlink()
+
+        sync_engine = create_engine(f"sqlite:///{db_path}")
+        SQLModel.metadata.create_all(sync_engine)
+        async_engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+
+        try:
+            async with AsyncSession(async_engine) as session:
+                contest = await upsert_contest_by_pandascore(
+                    session,
+                    {
+                        "pandascore_league_id": 1,
+                        "pandascore_serie_id": 2,
+                        "name": "LCK Spring",
+                        "start_date": datetime(
+                            2026, 3, 14, 10, 0, tzinfo=timezone.utc
+                        ),
+                        "end_date": datetime(
+                            2026, 3, 14, 10, 0, tzinfo=timezone.utc
+                        ),
+                        "tier": "S",
+                    },
+                )
+                assert contest is not None
+                assert contest.tier == "S"
+        finally:
+            sync_engine.dispose()
+            await async_engine.dispose()
+            if db_path.exists():
+                db_path.unlink()
 
 
 class TestPandaScoreClientRateLimiting:

--- a/tests/test_pandascore.py
+++ b/tests/test_pandascore.py
@@ -4,6 +4,7 @@ Unit tests for PandaScore client and sync logic.
 
 from datetime import datetime, timezone
 from pathlib import Path
+from uuid import uuid4
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -559,13 +560,14 @@ class TestPandaScoreSyncIntegration:
         from sqlmodel.ext.asyncio.session import AsyncSession
         from sqlalchemy.ext.asyncio import create_async_engine
 
-        from src.crud.contest import upsert_contest_by_pandascore
+        from src.crud.contest import (
+            get_contest_by_pandascore_ids,
+            upsert_contest_by_pandascore,
+        )
 
-        db_path = Path("data") / "contest-tier-test.db"
-        db_path.parent.mkdir(exist_ok=True)
-        if db_path.exists():
-            db_path.unlink()
-
+        temp_root = Path(".pytest_tmp")
+        temp_root.mkdir(exist_ok=True)
+        db_path = temp_root / f"contest-tier-{uuid4().hex}.db"
         sync_engine = create_engine(f"sqlite:///{db_path}")
         SQLModel.metadata.create_all(sync_engine)
         async_engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
@@ -588,7 +590,17 @@ class TestPandaScoreSyncIntegration:
                     },
                 )
                 assert contest is not None
-                assert contest.tier == "S"
+                await session.commit()
+
+            async with AsyncSession(async_engine) as session:
+                persisted = await get_contest_by_pandascore_ids(
+                    session,
+                    1,
+                    2,
+                )
+
+            assert persisted is not None
+            assert persisted.tier == "S"
         finally:
             sync_engine.dispose()
             await async_engine.dispose()


### PR DESCRIPTION
## Summary

- add nullable contest tier storage and migration
- surface compact match metadata in /matches and /pick
- show contest tier in live message contest labels when available

## Validation

- python -m flake8 src tests alembic --jobs=1
- black --check on the touched files and repo-safe scope was attempted; the CLI hangs intermittently in this environment after doing the work
- targeted pytest passed: tests/test_matches_result_display.py tests/commands/test_pick_view.py tests/test_new_commands.py tests/test_pandascore.py tests/test_live_messages.py
- full pytest was run and reached 125 passing tests, but remaining failures are the existing Windows tmp_path permission issue under C:\Users\super\AppData\Local\Temp\pytest-of-super, not code failures from this change