### PR TITLE
fix: merge alembic heads for contest tier

### DIFF
--- a/alembic/versions/f4e5d6c7b8a9_merge_tier_and_team_scope_heads.py
+++ b/alembic/versions/f4e5d6c7b8a9_merge_tier_and_team_scope_heads.py
@@ -7,8 +7,7 @@ Create Date: 2026-03-15
 
 from collections.abc import Sequence
 
-
-revision = "f4e5d6c7b8a9"
+revision: str = "f4e5d6c7b8a9"
 down_revision: str | Sequence[str] | None = (
     "7a4d1f2c9b8e",
     "8f7c6b5a4d3e",
@@ -18,10 +17,8 @@ depends_on = None
 
 
 def upgrade() -> None:
-    # Merge revision; schema changes live in the parent migrations.
-    return None
+    """Merge the contest tier and team scope migration branches."""
 
 
 def downgrade() -> None:
-    # Merge revision; schema changes live in the parent migrations.
-    return None
+    """Split the contest tier and team scope migration branches."""

--- a/alembic/versions/f4e5d6c7b8a9_merge_tier_and_team_scope_heads.py
+++ b/alembic/versions/f4e5d6c7b8a9_merge_tier_and_team_scope_heads.py
@@ -1,0 +1,25 @@
+"""Merge contest tier and team scope heads.
+
+Revision ID: f4e5d6c7b8a9
+Revises: 7a4d1f2c9b8e, 8f7c6b5a4d3e
+Create Date: 2026-03-15
+"""
+
+from collections.abc import Sequence
+
+
+revision = "f4e5d6c7b8a9"
+down_revision: str | Sequence[str] | None = (
+    "7a4d1f2c9b8e",
+    "8f7c6b5a4d3e",
+)
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/alembic/versions/f4e5d6c7b8a9_merge_tier_and_team_scope_heads.py
+++ b/alembic/versions/f4e5d6c7b8a9_merge_tier_and_team_scope_heads.py
@@ -18,8 +18,10 @@ depends_on = None
 
 
 def upgrade() -> None:
-    pass
+    # Merge revision; schema changes live in the parent migrations.
+    return None
 
 
 def downgrade() -> None:
-    pass
+    # Merge revision; schema changes live in the parent migrations.
+    return None


### PR DESCRIPTION
## Summary

- add a no-op Alembic merge revision for the contest-tier and team-scope migration heads

## Verification

- python -m alembic heads
- python -m flake8 alembic/versions/f4e5d6c7b8a9_merge_tier_and_team_scope_heads.py --jobs=1