### PR TITLE
fix: read tournament tier from PandaScore matches

### DIFF
--- a/src/contest_tier.py
+++ b/src/contest_tier.py
@@ -47,14 +47,17 @@ def normalize_contest_tier(raw_tier: Any) -> Optional[str]:
 def extract_contest_tier(match_data: dict[str, Any]) -> Optional[str]:
     league = match_data.get("league") or {}
     serie = match_data.get("serie") or {}
+    tournament = match_data.get("tournament") or {}
 
     candidates = (
         match_data.get("tier"),
         league.get("tier"),
         serie.get("tier"),
+        tournament.get("tier"),
         match_data.get("tournament_tier"),
         league.get("tournament_tier"),
         serie.get("tournament_tier"),
+        tournament.get("tournament_tier"),
     )
     for candidate in candidates:
         normalized = normalize_contest_tier(candidate)

--- a/tests/test_contest_tier.py
+++ b/tests/test_contest_tier.py
@@ -40,6 +40,31 @@ def test_lol_parser_extract_contest_data_includes_tier():
     assert result["tier"] == "S"
 
 
+def test_lol_parser_extract_contest_data_uses_tournament_tier():
+    parser = LoLParser()
+    match_data = {
+        "league": {
+            "id": 4553,
+            "name": "LCK Challengers League",
+            "image_url": "https://cdn.pandascore.co/images/league/image.png",
+        },
+        "serie": {
+            "id": 8889,
+            "name": "Kickoff",
+            "full_name": "Kickoff 2025",
+        },
+        "tournament": {
+            "id": 15744,
+            "name": "Playoffs",
+            "tier": "c",
+        },
+        "scheduled_at": "2025-02-17T09:00:00Z",
+    }
+
+    result = parser.extract_contest_data(match_data)
+    assert result["tier"] == "C"
+
+
 @pytest.mark.asyncio
 async def test_upsert_contest_by_pandascore_persists_tier():
     temp_root = Path(".pytest_tmp")


### PR DESCRIPTION
## Summary

- read contest tier from the PandaScore `tournament` object in addition to existing league/serie sources
- add regression coverage for the LoL matches payload shape where `tournament.tier` is present

## Validation

- python -m pytest tests/test_contest_tier.py tests/test_matches_result_display.py tests/test_new_commands.py
- python -m flake8 src/contest_tier.py tests/test_contest_tier.py --jobs=1

## Context

PandaScore match-list responses can provide the tier under `tournament.tier` (for example `"tier": "c"`), which was not previously considered during contest extraction.