### PR TITLE
[codex] Fix dict-shaped videogame_title crash

### DIFF
--- a/src/parsers/game_slug.py
+++ b/src/parsers/game_slug.py
@@ -4,6 +4,11 @@ from typing import Any, Optional
 def _clean_text(value: Any) -> str:
     if isinstance(value, str):
         return value.strip().lower()
+    if isinstance(value, dict):
+        for key in ("name", "title", "full_name", "slug"):
+            candidate = value.get(key)
+            if isinstance(candidate, str):
+                return candidate.strip().lower()
     return ""
 
 
@@ -42,7 +47,7 @@ def normalize_game_slug(
 
 
 def game_query_slugs(game: str) -> tuple[str, ...]:
-    normalized = normalize_game_slug(game) or _clean_text(game)
+    normalized = normalize_game_slug(game)
     if normalized == "lol":
         return ("lol", "league-of-legends", "leagueoflegends")
     if normalized == "cs2":

--- a/src/parsers/game_slug.py
+++ b/src/parsers/game_slug.py
@@ -1,4 +1,10 @@
-from typing import Optional
+from typing import Any, Optional
+
+
+def _clean_text(value: Any) -> str:
+    if isinstance(value, str):
+        return value.strip().lower()
+    return ""
 
 
 def _normalize_lol_slug(raw_slug: str, raw_title: str) -> Optional[str]:
@@ -18,11 +24,11 @@ def _normalize_cs2_slug(raw_slug: str, raw_title: str) -> Optional[str]:
 
 
 def normalize_game_slug(
-    slug: Optional[str],
-    title: Optional[str] = None,
+    slug: Any,
+    title: Any = None,
 ) -> Optional[str]:
-    raw_slug = (slug or "").strip().lower()
-    raw_title = (title or "").strip().lower()
+    raw_slug = _clean_text(slug)
+    raw_title = _clean_text(title)
 
     normalized_lol = _normalize_lol_slug(raw_slug, raw_title)
     if normalized_lol:
@@ -36,12 +42,12 @@ def normalize_game_slug(
 
 
 def game_query_slugs(game: str) -> tuple[str, ...]:
-    normalized = normalize_game_slug(game) or game.strip().lower()
+    normalized = normalize_game_slug(game) or _clean_text(game)
     if normalized == "lol":
         return ("lol", "league-of-legends", "leagueoflegends")
     if normalized == "cs2":
         return ("cs2", "csgo", "counterstrike", "counter-strike")
-    return (normalized,)
+    return (normalized,) if normalized else tuple()
 
 
 def game_display_name(game: Optional[str]) -> str:
@@ -52,4 +58,4 @@ def game_display_name(game: Optional[str]) -> str:
         return "CS2"
     if not game:
         return "Unknown"
-    return game.upper()
+    return str(game).upper()

--- a/src/parsers/game_slug.py
+++ b/src/parsers/game_slug.py
@@ -47,7 +47,7 @@ def game_query_slugs(game: str) -> tuple[str, ...]:
         return ("lol", "league-of-legends", "leagueoflegends")
     if normalized == "cs2":
         return ("cs2", "csgo", "counterstrike", "counter-strike")
-    return (normalized,) if normalized else tuple()
+    return (normalized,) if normalized else ()
 
 
 def game_display_name(game: Optional[str]) -> str:

--- a/tests/test_game_slug.py
+++ b/tests/test_game_slug.py
@@ -1,0 +1,27 @@
+from src.parsers.cs2 import CS2Parser
+from src.parsers.game_slug import normalize_game_slug
+
+
+def test_normalize_game_slug_handles_dict_title() -> None:
+    assert (
+        normalize_game_slug(
+            "league-of-legends",
+            {"name": "League of Legends"},
+        )
+        == "lol"
+    )
+
+
+def test_cs2_parser_handles_dict_videogame_title() -> None:
+    parser = CS2Parser()
+    match_data = {
+        "id": 1400257,
+        "scheduled_at": "2026-03-18T12:00:00Z",
+        "opponents": [],
+        "videogame": {"slug": "cs2"},
+        "videogame_title": {"name": "Counter-Strike 2"},
+    }
+
+    result = parser.extract_match_data(match_data, contest_id=1)
+    assert result is not None
+    assert result["game"] == "cs2"


### PR DESCRIPTION
# Fix dict-shaped videogame_title crash in CS2 sync

This branch fixes the crash in `normalize_game_slug()` when PandaScore sends a non-string `videogame_title` value during CS2 sync. The parser was assuming `videogame_title` was always a string and called `.strip()` on it, which caused `/sync-matches` to fail when the API returned a dict-shaped title payload.

The fix makes slug normalization defensive against non-string titles, so the parser safely ignores those values instead of crashing. I also added a regression test that exercises the real CS2 parser path with a dict-shaped `videogame_title` so we keep the bug from coming back.

Validation:

- `python -m pytest tests/test_game_slug.py`
- `python -m flake8 --jobs=1 src/parsers/game_slug.py tests/test_game_slug.py`