### PR TITLE
feat: add Valorant parser adapter

### DIFF
--- a/src/parsers/factory.py
+++ b/src/parsers/factory.py
@@ -5,10 +5,12 @@ from typing import Optional
 from src.parsers.lol import LoLParser
 from src.parsers.base import PandaScoreParser
 from src.parsers.cs2 import CS2Parser
+from src.parsers.valorant import ValorantParser
 
 _PARSERS = {
     "lol": LoLParser,
     "cs2": CS2Parser,
+    "valorant": ValorantParser,
 }
 
 

--- a/src/parsers/game_slug.py
+++ b/src/parsers/game_slug.py
@@ -28,6 +28,14 @@ def _normalize_cs2_slug(raw_slug: str, raw_title: str) -> Optional[str]:
     return None
 
 
+def _normalize_valorant_slug(raw_slug: str, raw_title: str) -> Optional[str]:
+    if raw_slug in {"valorant", "val", "vct"}:
+        return "valorant"
+    if "valorant" in raw_title:
+        return "valorant"
+    return None
+
+
 def normalize_game_slug(
     slug: Any,
     title: Any = None,
@@ -43,6 +51,10 @@ def normalize_game_slug(
     if normalized_cs2:
         return normalized_cs2
 
+    normalized_valorant = _normalize_valorant_slug(raw_slug, raw_title)
+    if normalized_valorant:
+        return normalized_valorant
+
     return raw_slug or None
 
 
@@ -52,6 +64,8 @@ def game_query_slugs(game: str) -> tuple[str, ...]:
         return ("lol", "league-of-legends", "leagueoflegends")
     if normalized == "cs2":
         return ("cs2", "csgo", "counterstrike", "counter-strike")
+    if normalized == "valorant":
+        return ("valorant", "val", "vct")
     return (normalized,) if normalized else ()
 
 
@@ -61,6 +75,8 @@ def game_display_name(game: Optional[str]) -> str:
         return "LoL"
     if normalized == "cs2":
         return "CS2"
+    if normalized == "valorant":
+        return "Valorant"
     if not game:
         return "Unknown"
     return str(game).upper()

--- a/src/parsers/valorant.py
+++ b/src/parsers/valorant.py
@@ -1,0 +1,143 @@
+"""
+Valorant Parser adapter implementing the PandaScoreParser interface.
+Handles VCT matches with best-of series format.
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from src.parsers.base import PandaScoreParser
+from src.contest_tier import extract_contest_tier
+from src.parsers.game_slug import normalize_game_slug
+
+logger = logging.getLogger(__name__)
+
+
+def _extract_opponent_info(
+    match_data: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    opponents = match_data.get("opponents", [])
+    team_infos = [opponent.get("opponent", {}) for opponent in opponents[:2]]
+    while len(team_infos) < 2:
+        team_infos.append({})
+    return team_infos[0], team_infos[1]
+
+
+def _team_display_name(team_info: dict[str, Any]) -> str:
+    return team_info.get("name") or team_info.get("acronym") or "TBD"
+
+
+def _match_game_slug(match_data: dict[str, Any]) -> str:
+    videogame = match_data.get("videogame") or {}
+    return (
+        normalize_game_slug(
+            videogame.get("slug"),
+            match_data.get("videogame_title"),
+        )
+        or "valorant"
+    )
+
+
+class ValorantParser(PandaScoreParser):
+    """Parser for Valorant matches.
+
+    Follows the same contract as LoLParser and CS2Parser. Handles VCT
+    tournament formats including best-of series.
+    """
+
+    @staticmethod
+    def extract_team_data(
+        opponent: dict[str, Any],
+    ) -> Optional[dict[str, Any]]:
+        """Extract team data from opponent object."""
+        team_info = opponent.get("opponent")
+        if not team_info:
+            return None
+
+        return {
+            "pandascore_id": team_info.get("id"),
+            "name": team_info.get("name"),
+            "acronym": team_info.get("acronym"),
+            "image_url": team_info.get("image_url"),
+        }
+
+    @staticmethod
+    def extract_contest_data(match_data: dict[str, Any]) -> dict[str, Any]:
+        """Extract contest (league/series) data from match object."""
+        league = match_data.get("league", {})
+        serie = match_data.get("serie", {})
+
+        league_name = league.get("name", "Unknown League")
+        serie_name = serie.get("full_name") or serie.get("name", "")
+        contest_name = f"{league_name} {serie_name}".strip()
+
+        scheduled_at = PandaScoreParser.parse_date(
+            match_data.get("scheduled_at")
+        )
+        now = (
+            scheduled_at
+            if scheduled_at is not None
+            else datetime.now(timezone.utc)
+        )
+
+        return {
+            "pandascore_league_id": league.get("id"),
+            "pandascore_serie_id": serie.get("id"),
+            "name": contest_name,
+            "start_date": scheduled_at or now,
+            "end_date": scheduled_at or now,
+            "image_url": league.get("image_url"),
+            "tier": extract_contest_tier(match_data),
+        }
+
+    @staticmethod
+    def extract_match_data(
+        match_data: dict[str, Any], contest_id: int
+    ) -> Optional[dict[str, Any]]:
+        """Extract match data from PandaScore match object."""
+        pandascore_id = match_data.get("id")
+        scheduled_at = PandaScoreParser.parse_date(
+            match_data.get("scheduled_at")
+        )
+
+        if not pandascore_id or not scheduled_at:
+            logger.warning(
+                "Valorant match missing id or scheduled_at: %s", match_data
+            )
+            return None
+
+        team1_info, team2_info = _extract_opponent_info(match_data)
+
+        return {
+            "pandascore_id": pandascore_id,
+            "contest_id": contest_id,
+            "game": _match_game_slug(match_data),
+            "team1": _team_display_name(team1_info),
+            "team2": _team_display_name(team2_info),
+            "team1_id": team1_info.get("id"),
+            "team2_id": team2_info.get("id"),
+            "best_of": match_data.get("number_of_games"),
+            "status": match_data.get("status", "not_started"),
+            "scheduled_time": scheduled_at,
+        }
+
+    @staticmethod
+    def extract_winner_and_scores(
+        match_data: dict[str, Any], match: Any, winner_id: Any
+    ) -> tuple[Optional[str], int, int]:
+        """Extract winner name and scores from match result."""
+        results = match_data.get("results") or []
+        scores = {
+            r.get("team_id"): (r.get("score") or 0)
+            for r in results
+            if r.get("team_id") is not None
+        }
+
+        team1_score = scores.get(match.team1_id, 0)
+        team2_score = scores.get(match.team2_id, 0)
+
+        id_to_name = {match.team1_id: match.team1, match.team2_id: match.team2}
+        winner_name = id_to_name.get(winner_id)
+
+        return winner_name, team1_score, team2_score

--- a/tests/test_game_slug.py
+++ b/tests/test_game_slug.py
@@ -1,5 +1,6 @@
 from src.parsers.cs2 import CS2Parser
-from src.parsers.game_slug import normalize_game_slug
+from src.parsers.valorant import ValorantParser
+from src.parsers.game_slug import normalize_game_slug, game_display_name, game_query_slugs
 
 
 def test_normalize_game_slug_handles_dict_title() -> None:
@@ -25,3 +26,82 @@ def test_cs2_parser_handles_dict_videogame_title() -> None:
     result = parser.extract_match_data(match_data, contest_id=1)
     assert result is not None
     assert result["game"] == "cs2"
+
+
+def test_normalize_valorant_slug() -> None:
+    assert normalize_game_slug("valorant") == "valorant"
+    assert normalize_game_slug("val") == "valorant"
+    assert normalize_game_slug("vct") == "valorant"
+    assert normalize_game_slug("valorant", "VCT 2026") == "valorant"
+
+
+def test_valorant_display_name() -> None:
+    assert game_display_name("valorant") == "Valorant"
+    assert game_display_name("val") == "Valorant"
+
+
+def test_valorant_query_slugs() -> None:
+    slugs = game_query_slugs("valorant")
+    assert "valorant" in slugs
+    assert "val" in slugs
+    assert "vct" in slugs
+
+
+def test_valorant_parser_extracts_match_data() -> None:
+    parser = ValorantParser()
+    match_data = {
+        "id": 9999001,
+        "scheduled_at": "2026-04-01T18:00:00Z",
+        "opponents": [
+            {"opponent": {"id": 12345, "name": "Sentinels", "acronym": "SEN", "image_url": "https://example.com/sen.png"}},
+            {"opponent": {"id": 12346, "name": "Cloud9", "acronym": "C9", "image_url": "https://example.com/c9.png"}},
+        ],
+        "videogame": {"slug": "valorant"},
+        "league": {"id": 4378, "name": "VCT Americas", "image_url": "https://example.com/vct.png"},
+        "serie": {"id": 7890, "full_name": "Stage 1"},
+        "number_of_games": 3,
+        "status": "not_started",
+    }
+
+    result = parser.extract_match_data(match_data, contest_id=1)
+    assert result is not None
+    assert result["game"] == "valorant"
+    assert result["team1"] == "Sentinels"
+    assert result["team2"] == "Cloud9"
+    assert result["best_of"] == 3
+
+
+def test_valorant_parser_extracts_contest() -> None:
+    parser = ValorantParser()
+    match_data = {
+        "league": {"id": 4378, "name": "VCT Americas", "image_url": "https://example.com/vct.png"},
+        "serie": {"id": 7890, "full_name": "Stage 1"},
+        "scheduled_at": "2026-04-01T18:00:00Z",
+    }
+
+    contest = parser.extract_contest_data(match_data)
+    assert contest["name"] == "VCT Americas Stage 1"
+    assert contest["pandascore_league_id"] == 4378
+
+
+def test_valorant_parser_extracts_winner_and_scores() -> None:
+    parser = ValorantParser()
+    match_data = {
+        "results": [
+            {"team_id": 12345, "score": 2},
+            {"team_id": 12346, "score": 1},
+        ]
+    }
+    # Mock match object
+    class MockMatch:
+        team1_id = 12345
+        team2_id = 12346
+        team1 = "Sentinels"
+        team2 = "Cloud9"
+
+    winner_name, team1_score, team2_score = parser.extract_winner_and_scores(
+        match_data, MockMatch(), 12345
+    )
+    assert winner_name == "Sentinels"
+    assert team1_score == 2
+    assert team2_score == 1


### PR DESCRIPTION
## Summary

- Add `ValorantParser` class implementing the `PandaScoreParser` interface
- Add Valorant slug normalization (`valorant`, `val`, `vct`)
- Register Valorant parser in the parser factory
- Add 6 new tests for Valorant parsing, slug normalization, and display names

## Changes

- **src/parsers/valorant.py** — New parser adapter for VCT matches
- **src/parsers/game_slug.py** — Added Valorant slug normalization
- **src/parsers/factory.py** — Registered ValorantParser
- **tests/test_game_slug.py** — Added Valorant test cases

## Testing

- All 151 tests pass (0 failures)
- New tests cover: slug normalization, display names, query slugs, match extraction, contest extraction, winner/score extraction

## Notes

- Follows the same pattern as LoLParser and CS2Parser
- Uses existing contest tier extraction
- Handles BO3/BO5 series format via `number_of_games`

Closes #156