### PR TITLE
docs: combine v1.2/v1.3; update ROADMAP and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- markdownlint-disable -->
 
+## [v1.3] - 2026-04-16
+
+### Added
+
+- Release consolidation: v1.2 and v1.3 combined; CS2 parser stabilized and merged into main (`src/parsers/cs2.py`).
+
+### Changed
+
+- Roadmap updated to reflect the combined v1.2/v1.3 release and CS2 availability.
+
 ## [v1.2] - 2026-03-11
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,9 +49,9 @@ Milestones are scoped for fast, incremental releases. Each milestone below maps 
 
 **Estimate:** 1–3 weeks.
 
-### v1.2 — Refactor & Hardening (Milestone A)
+### v1.2/v1.3 — Refactor, Hardening & CS2 (Released)
 
-**Goal:** provide a reusable adapter and harden polling.
+**Goal:** provide a reusable adapter, harden polling, and deliver CS2 support.
 
 **Checklist:**
 
@@ -65,25 +65,13 @@ Milestones are scoped for fast, incremental releases. Each milestone below maps 
 
 - Add fixtures and mocked PandaScore responses; extend unit/integration tests and CI to run them.
 
-**Acceptance:** no regressions vs v1.0; CI passing; documented rollback path.
-
-**Estimate:** 2–4 weeks.
-
-### v1.3 — CS2 (Counter-Strike)
-
-**Goal:** CS2 MVP using the adapter template.
-
-**Checklist:**
-
-- Implement `parsers/cs2.py` following the adapter interface.
-
-- Add per-title configuration and enable flag.
+- Implement `parsers/cs2.py` and wire CS2 into sync/polling/notification flows; add per-title configuration and tests.
 
 - Apply DB/Alembic migrations for map/series fields if required.
 
-- Add recorded fixtures and tests.
+**Acceptance:** CS2 parser merged and enabled; no regressions; CI passing; documented rollback path.
 
-**Estimate:** 1–3 weeks (CS2 may need extra work for map/series parsing).
+**Estimate:** 2–4 weeks (combined).
 
 ### v1.4 — Fan Experience: Watchlist & Catchup (feature)
 


### PR DESCRIPTION
Combine v1.2 and v1.3 into a single release entry and update ROADMAP and CHANGELOG to reflect CS2 parser being merged into main.

Files changed: ROADMAP.md, CHANGELOG.md

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>