### PR TITLE
tooling: fix Black temp-dir traversal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,5 +214,6 @@ logs/
 # Temporary files
 tmp/
 temp/
+.pytest_tmp/
 docs/personal/*
 TODO.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,6 @@ testpaths = ["tests"]
 
 [tool.black]
 line-length = 79
+extend-exclude = '''
+(^|/)\.pytest_tmp(/|$)
+'''

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ alembic==1.18.4
 apscheduler
 aiohttp
 aiosqlite
-tenacity

--- a/src/watchlist_reminder.py
+++ b/src/watchlist_reminder.py
@@ -162,9 +162,7 @@ async def send_watchlist_reminders_job(
     """
     bot = get_bot_instance()
     if bot is None:
-        logger.debug(
-            "No bot instance available; skipping watchlist reminders"
-        )
+        logger.debug("No bot instance available; skipping watchlist reminders")
         return
 
     now = datetime.now(timezone.utc)

--- a/tests/test_contest_tier.py
+++ b/tests/test_contest_tier.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timezone
-from uuid import uuid4
 
 import pytest
 from sqlmodel import SQLModel, create_engine
@@ -66,7 +65,7 @@ def test_lol_parser_extract_contest_data_uses_tournament_tier():
 
 @pytest.mark.asyncio
 async def test_upsert_contest_by_pandascore_persists_tier(tmp_path):
-    db_path = tmp_path / f"contest-tier-{uuid4().hex}.db"
+    db_path = tmp_path / "contest-tier.db"
     sync_engine = create_engine(f"sqlite:///{db_path}")
     SQLModel.metadata.create_all(sync_engine)
     async_engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")

--- a/tests/test_contest_tier.py
+++ b/tests/test_contest_tier.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timezone
-from pathlib import Path
 from uuid import uuid4
 
 import pytest
@@ -66,10 +65,8 @@ def test_lol_parser_extract_contest_data_uses_tournament_tier():
 
 
 @pytest.mark.asyncio
-async def test_upsert_contest_by_pandascore_persists_tier():
-    temp_root = Path(".pytest_tmp")
-    temp_root.mkdir(exist_ok=True)
-    db_path = temp_root / f"contest-tier-{uuid4().hex}.db"
+async def test_upsert_contest_by_pandascore_persists_tier(tmp_path):
+    db_path = tmp_path / f"contest-tier-{uuid4().hex}.db"
     sync_engine = create_engine(f"sqlite:///{db_path}")
     SQLModel.metadata.create_all(sync_engine)
     async_engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")


### PR DESCRIPTION
## What changed

- Ignored `.pytest_tmp` in git and Black so local pytest scratch files no longer break `python -m black --check .` on Windows.
- Switched the contest tier test to `tmp_path` so it no longer creates repo-local temp state.
- Removed the unused `tenacity` dependency.

## Notes

- The worktree is clean after commit.
- I also wrote a comprehensive review report in `docs/personal/comprehensive-review-report.md` for verification purposes; it is gitignored and not part of the PR.